### PR TITLE
Add PullRequestService.reviews() and cycleTime() 

### DIFF
--- a/src/modules/pull-requests/PullRequestService.ts
+++ b/src/modules/pull-requests/PullRequestService.ts
@@ -10,13 +10,20 @@ import {
     UpdatePullRequestParams,
     MergePullRequestResponse,
     UpdatePullRequestBranchResponse,
+    PullRequestReview,
+    PullRequestCycleTime,
 } from "./pull-request.types";
-import { PullRequestDTO, PullRequestFileDTO } from "./pull-request.dto";
+import {
+    PullRequestDTO,
+    PullRequestFileDTO,
+    PullRequestReviewDTO,
+} from "./pull-request.dto";
 import {
     mapCreatePullRequestParams,
     mapMergePullRequestParams,
     mapPullRequest,
     mapPullRequestFiles,
+    mapPullRequestReviews,
     mapPullRequests,
     mapUpdatePullRequestParams,
 } from "./pull-request.mapper";
@@ -236,5 +243,51 @@ export class PullRequestService {
                 },
             );
         return response.data;
+    }
+
+    /**
+     * List reviews on a pull request
+     *
+     * @param pullNumber The number that identifies the pull request
+     * @returns Array of pull request reviews
+     *
+     * @example
+     * ```ts
+     * const reviews = await github.pullRequests.reviews(8);
+     * ```
+     */
+    public async reviews(pullNumber: number): Promise<PullRequestReview[]> {
+        const response = await this.client.request<PullRequestReviewDTO[]>(
+            `${this.path}/${pullNumber}/reviews`,
+        );
+        return mapPullRequestReviews(response.data);
+    }
+
+    /**
+     * Get the cycle time of a pull request — the duration from when it was
+     * opened to when it was merged
+     *
+     * @param pullNumber The number that identifies the pull request
+     * @returns Cycle time data. `mergedAt`, `totalMs`, and `totalHours` are
+     * `null` if the pull request has not been merged
+     *
+     * @example
+     * ```ts
+     * const cycleTime = await github.pullRequests.cycleTime(8);
+     * ```
+     */
+    public async cycleTime(pullNumber: number): Promise<PullRequestCycleTime> {
+        const pullRequest = await this.get(pullNumber);
+        const totalMs = pullRequest.mergedAt
+            ? new Date(pullRequest.mergedAt).getTime() -
+              new Date(pullRequest.createdAt).getTime()
+            : null;
+
+        return {
+            openedAt: pullRequest.createdAt,
+            mergedAt: pullRequest.mergedAt,
+            totalMs,
+            totalHours: totalMs !== null ? totalMs / (1000 * 60 * 60) : null,
+        };
     }
 }

--- a/src/modules/pull-requests/pull-request.dto.ts
+++ b/src/modules/pull-requests/pull-request.dto.ts
@@ -1,4 +1,8 @@
-import { PullRequestFileStatus, PullRequestState } from "./pull-request.types";
+import {
+    PullRequestFileStatus,
+    PullRequestReviewState,
+    PullRequestState,
+} from "./pull-request.types";
 import { UserDTO } from "../users/user.dto";
 
 export interface BranchRefDTO {
@@ -43,4 +47,16 @@ export interface PullRequestFileDTO {
     raw_url: string;
     contents_url: string;
     patch: string | null;
+}
+
+export interface PullRequestReviewDTO {
+    id: number;
+    node_id: string;
+    user: UserDTO;
+    body: string;
+    state: PullRequestReviewState;
+    html_url: string;
+    pull_request_url: string;
+    submitted_at?: string;
+    commit_id: string;
 }

--- a/src/modules/pull-requests/pull-request.mapper.ts
+++ b/src/modules/pull-requests/pull-request.mapper.ts
@@ -8,11 +8,13 @@ import {
     UpdatePullRequestPayload,
     MergePullRequestParams,
     MergePullRequestPayload,
+    PullRequestReview,
 } from "./pull-request.types";
 import {
     BranchRefDTO,
     PullRequestDTO,
     PullRequestFileDTO,
+    PullRequestReviewDTO,
 } from "./pull-request.dto";
 import { mapUser } from "../users/user.mapper";
 
@@ -100,6 +102,28 @@ export function mapUpdatePullRequestParams(
         base: params.base,
         maintainer_can_modify: params.maintainerCanModify,
     };
+}
+
+export function mapPullRequestReview(
+    dto: PullRequestReviewDTO,
+): PullRequestReview {
+    return {
+        id: dto.id,
+        nodeId: dto.node_id,
+        user: mapUser(dto.user),
+        body: dto.body,
+        state: dto.state,
+        url: dto.html_url,
+        apiUrl: dto.pull_request_url,
+        submittedAt: dto.submitted_at ?? null,
+        commitId: dto.commit_id,
+    };
+}
+
+export function mapPullRequestReviews(
+    dtos: PullRequestReviewDTO[],
+): PullRequestReview[] {
+    return dtos.map((dto) => mapPullRequestReview(dto));
 }
 
 export function mapMergePullRequestParams(

--- a/src/modules/pull-requests/pull-request.types.ts
+++ b/src/modules/pull-requests/pull-request.types.ts
@@ -10,6 +10,8 @@ export type PullRequestFileStatus =
     | "changed"
     | "unchanged";
 export type PullRequestMergeMethod = "merge" | "squash" | "rebase";
+export type PullRequestReviewState =
+    "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED" | "PENDING";
 
 export interface BranchRef {
     ref: string;
@@ -117,4 +119,23 @@ export interface MergePullRequestResponse {
 export interface UpdatePullRequestBranchResponse {
     message: string;
     url: string;
+}
+
+export interface PullRequestReview {
+    id: number;
+    nodeId: string;
+    user: User;
+    body: string;
+    state: PullRequestReviewState;
+    url: string;
+    apiUrl: string;
+    submittedAt: string | null;
+    commitId: string;
+}
+
+export interface PullRequestCycleTime {
+    openedAt: string;
+    mergedAt: string | null;
+    totalMs: number | null;
+    totalHours: number | null;
 }

--- a/tests/unit/modules/pull-requests/PullRequestService.test.ts
+++ b/tests/unit/modules/pull-requests/PullRequestService.test.ts
@@ -1,6 +1,9 @@
 import { GithubClient } from "../../../../src/client/GithubClient";
 import { PullRequestService } from "../../../../src/modules/pull-requests/PullRequestService";
-import { PullRequestDTO } from "../../../../src/modules/pull-requests/pull-request.dto";
+import {
+    PullRequestDTO,
+    PullRequestReviewDTO,
+} from "../../../../src/modules/pull-requests/pull-request.dto";
 import { UserDTO } from "../../../../src/modules/users/user.dto";
 import { GithubApiError } from "../../../../src/shared/errors/GithubApiError";
 
@@ -52,6 +55,18 @@ const mockPullRequestDto: PullRequestDTO = {
     merged: false,
     head: { ref: "feature", sha: "abc123" },
     base: { ref: "main", sha: "def456" },
+};
+
+const mockReviewDto: PullRequestReviewDTO = {
+    id: 1,
+    node_id: "PRR_1",
+    user: mockUserDto,
+    body: "Looks good",
+    state: "APPROVED",
+    html_url: "https://github.com/owner/repo/pull/8#pullrequestreview-1",
+    pull_request_url: "https://api.github.com/repos/owner/repo/pulls/8",
+    submitted_at: "2024-01-02T00:00:00Z",
+    commit_id: "abc123",
 };
 
 function makeService() {
@@ -126,6 +141,75 @@ describe("PullRequestService", () => {
                 new GithubApiError(500, "Internal Server Error"),
             );
             await expect(service.isMerged(8)).rejects.toThrow(GithubApiError);
+        });
+    });
+
+    describe("reviews", () => {
+        it("calls GET /repos/:owner/:repo/pulls/:number/reviews", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: [mockReviewDto],
+                status: 200,
+            });
+            await service.reviews(8);
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/pulls/8/reviews",
+            );
+        });
+
+        it("returns an array of mapped PullRequestReviews", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: [mockReviewDto],
+                status: 200,
+            });
+            const result = await service.reviews(8);
+            expect(Array.isArray(result)).toBe(true);
+            expect(result[0].state).toBe("APPROVED");
+            expect(result[0].commitId).toBe("abc123");
+            expect(result[0].submittedAt).toBe("2024-01-02T00:00:00Z");
+        });
+
+        it("maps a missing submitted_at to null", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: [{ ...mockReviewDto, submitted_at: undefined }],
+                status: 200,
+            });
+            const result = await service.reviews(8);
+            expect(result[0].submittedAt).toBeNull();
+        });
+    });
+
+    describe("cycleTime", () => {
+        it("calculates totalMs and totalHours for a merged PR", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: {
+                    ...mockPullRequestDto,
+                    created_at: "2024-01-01T00:00:00Z",
+                    merged_at: "2024-01-01T02:00:00Z",
+                    merged: true,
+                },
+                status: 200,
+            });
+            const result = await service.cycleTime(8);
+            expect(result.openedAt).toBe("2024-01-01T00:00:00Z");
+            expect(result.mergedAt).toBe("2024-01-01T02:00:00Z");
+            expect(result.totalMs).toBe(2 * 60 * 60 * 1000);
+            expect(result.totalHours).toBe(2);
+        });
+
+        it("returns null durations for an unmerged PR", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: mockPullRequestDto,
+                status: 200,
+            });
+            const result = await service.cycleTime(8);
+            expect(result.mergedAt).toBeNull();
+            expect(result.totalMs).toBeNull();
+            expect(result.totalHours).toBeNull();
         });
     });
 });


### PR DESCRIPTION
reviews() lists reviews on a PR via a new PullRequestReview type/DTO/mapper. cycleTime() derives open-to-merge duration from data already on PullRequest, critical for Lujax Hub's PR cycle time feature.

Closes: #50, #51