### PR TITLE
 Add rate limiting, retry, and ETag caching to request.utils.ts

### DIFF
--- a/src/client/GithubClient.ts
+++ b/src/client/GithubClient.ts
@@ -1,7 +1,11 @@
 import { PullRequestService } from "../modules/pull-requests/PullRequestService";
 import { RepositoryService } from "../modules/repositories/RepositoryService";
 import { UserService } from "../modules/users/UserService";
-import { ApiResponse, request } from "../shared/utils/request.utils";
+import {
+    ApiResponse,
+    createRequestClient,
+    RequestClient,
+} from "../shared/utils/request.utils";
 
 export interface GithubClientConfig {
     token: string;
@@ -20,6 +24,7 @@ export class GithubClient {
     public readonly users: UserService;
     public readonly repositories: RepositoryService;
     public readonly baseUrl: string;
+    private readonly requestClient: RequestClient;
 
     /**
      * @param config GithubClient configuration
@@ -36,10 +41,11 @@ export class GithubClient {
      * ```
      */
     constructor(public readonly config: GithubClientConfig) {
+        this.baseUrl = "https://api.github.com";
+        this.requestClient = createRequestClient(this.baseUrl, config.token);
         this.pullRequests = new PullRequestService(this);
         this.users = new UserService(this);
         this.repositories = new RepositoryService(this);
-        this.baseUrl = "https://api.github.com";
     }
 
     /**
@@ -58,6 +64,6 @@ export class GithubClient {
         path: string,
         options?: RequestInit,
     ): Promise<ApiResponse<T>> {
-        return request<T>(this.baseUrl, path, options, this.config.token);
+        return this.requestClient<T>(path, options);
     }
 }

--- a/src/shared/utils/request.utils.ts
+++ b/src/shared/utils/request.utils.ts
@@ -11,31 +11,123 @@ export interface ApiResponse<T> {
     status: number;
 }
 
-export async function request<T>(
+export interface RequestClient {
+    <T>(path: string, options?: RequestInit): Promise<ApiResponse<T>>;
+}
+
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAYS_MS = [1000, 2000, 4000];
+
+function isRetryableStatus(status: number): boolean {
+    return status === 429 || (status >= 500 && status < 600);
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface CacheEntry {
+    etag: string;
+    data: unknown;
+}
+
+/**
+ * Builds a `request<T>` function bound to a base URL and token. Rate-limit
+ * state and the ETag cache are held in closure so each GithubClient instance
+ * (and each token) gets its own isolated state.
+ */
+export function createRequestClient(
     baseUrl: string,
-    path: string,
-    options: RequestInit = {},
     token: string,
-): Promise<ApiResponse<T>> {
-    const response = await fetch(`${baseUrl}${path}`, {
-        ...options,
-        headers: {
+): RequestClient {
+    let rateLimitRemaining: number | null = null;
+    let rateLimitResetAt: number | null = null;
+    const etagCache = new Map<string, CacheEntry>();
+
+    function updateRateLimitFromHeaders(headers: Headers): void {
+        const remaining = headers.get("x-ratelimit-remaining");
+        const reset = headers.get("x-ratelimit-reset");
+
+        if (remaining !== null) {
+            rateLimitRemaining = Number(remaining);
+        }
+        if (reset !== null) {
+            rateLimitResetAt = Number(reset) * 1000;
+        }
+    }
+
+    async function waitForRateLimit(): Promise<void> {
+        if (rateLimitRemaining !== 0 || rateLimitResetAt === null) {
+            return;
+        }
+        const waitMs = rateLimitResetAt - Date.now();
+        if (waitMs > 0) {
+            await sleep(waitMs);
+        }
+    }
+
+    return async function request<T>(
+        path: string,
+        options: RequestInit = {},
+    ): Promise<ApiResponse<T>> {
+        await waitForRateLimit();
+
+        const url = `${baseUrl}${path}`;
+        const isGet = (options.method ?? "GET").toUpperCase() === "GET";
+        const cached = isGet ? etagCache.get(url) : undefined;
+
+        const headers: Record<string, string> = {
             "X-GitHub-Api-Version": "2022-11-28",
             Authorization: `Bearer ${token}`,
             Accept: "application/vnd.github+json",
-            ...options.headers,
-        },
-    });
+            ...(options.headers as Record<string, string> | undefined),
+        };
+        if (cached) {
+            headers["If-None-Match"] = cached.etag;
+        }
 
-    const data = await response.json();
+        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+            const response = await fetch(url, { ...options, headers });
+            updateRateLimitFromHeaders(response.headers);
 
-    if (!response.ok) {
-        const error = data as GithubApiErrorResponse;
-        throw new GithubApiError(response.status, error.message);
-    }
+            if (response.status === 304 && cached) {
+                return { data: cached.data as T, status: 304 };
+            }
 
-    return {
-        data: data as T,
-        status: response.status,
+            if (isRetryableStatus(response.status)) {
+                const isLastAttempt = attempt === MAX_ATTEMPTS - 1;
+                if (!isLastAttempt) {
+                    await sleep(RETRY_DELAYS_MS[attempt]);
+                    continue;
+                }
+            }
+
+            const text = await response.text();
+            const data = text ? JSON.parse(text) : null;
+
+            if (!response.ok) {
+                const error = data as GithubApiErrorResponse;
+                throw new GithubApiError(
+                    response.status,
+                    error.message,
+                    error.documentation_url,
+                    error.details,
+                );
+            }
+
+            if (isGet) {
+                const etag = response.headers.get("etag");
+                if (etag) {
+                    etagCache.set(url, { etag, data });
+                }
+            }
+
+            return { data: data as T, status: response.status };
+        }
+
+        throw new GithubApiError(
+            500,
+            "Request failed after all retry attempts",
+        );
     };
 }

--- a/tests/unit/shared/utils/request.utils.test.ts
+++ b/tests/unit/shared/utils/request.utils.test.ts
@@ -1,0 +1,294 @@
+import { createRequestClient } from "../../../../src/shared/utils/request.utils";
+import { GithubApiError } from "../../../../src/shared/errors/GithubApiError";
+
+function mockResponse(
+    status: number,
+    body: unknown,
+    headers: Record<string, string> = {},
+): Response {
+    return {
+        status,
+        ok: status >= 200 && status < 300,
+        headers: new Headers(headers),
+        text: async () => (body === null ? "" : JSON.stringify(body)),
+    } as unknown as Response;
+}
+
+describe("createRequestClient", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+
+    it("sets the correct GitHub API headers", async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValue(mockResponse(200, { ok: true }));
+        global.fetch = fetchMock;
+
+        const client = createRequestClient(
+            "https://api.github.com",
+            "test-token",
+        );
+        await client("/some/path");
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://api.github.com/some/path",
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    "X-GitHub-Api-Version": "2022-11-28",
+                    Authorization: "Bearer test-token",
+                    Accept: "application/vnd.github+json",
+                }),
+            }),
+        );
+    });
+
+    it("throws GithubApiError with documentationUrl and details on a non-ok response", async () => {
+        global.fetch = jest.fn().mockResolvedValue(
+            mockResponse(422, {
+                message: "Validation Failed",
+                documentation_url: "https://docs.github.com/errors",
+                details: [{ field: "title" }],
+            }),
+        );
+
+        const client = createRequestClient(
+            "https://api.github.com",
+            "test-token",
+        );
+
+        await expect(client("/repos/owner/repo")).rejects.toMatchObject({
+            status: 422,
+            documentationUrl: "https://docs.github.com/errors",
+            details: [{ field: "title" }],
+        });
+    });
+
+    it("returns null data for empty-body responses (e.g. 204)", async () => {
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(204, null));
+
+        const client = createRequestClient(
+            "https://api.github.com",
+            "test-token",
+        );
+        const result = await client("/repos/owner/repo/pulls/1/merge");
+
+        expect(result.status).toBe(204);
+        expect(result.data).toBeNull();
+    });
+
+    describe("retry logic", () => {
+        it("retries on 503 and succeeds on the second attempt", async () => {
+            jest.useFakeTimers();
+            const fetchMock = jest
+                .fn()
+                .mockResolvedValueOnce(
+                    mockResponse(503, { message: "Service Unavailable" }),
+                )
+                .mockResolvedValueOnce(mockResponse(200, { ok: true }));
+            global.fetch = fetchMock;
+
+            const client = createRequestClient(
+                "https://api.github.com",
+                "test-token",
+            );
+
+            const promise = client("/repos/owner/repo");
+            await jest.advanceTimersByTimeAsync(1000);
+            const result = await promise;
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            expect(result.status).toBe(200);
+        });
+
+        it("retries on 429 the same as 5xx", async () => {
+            jest.useFakeTimers();
+            const fetchMock = jest
+                .fn()
+                .mockResolvedValueOnce(
+                    mockResponse(429, { message: "Too Many Requests" }),
+                )
+                .mockResolvedValueOnce(mockResponse(200, { ok: true }));
+            global.fetch = fetchMock;
+
+            const client = createRequestClient(
+                "https://api.github.com",
+                "test-token",
+            );
+
+            const promise = client("/repos/owner/repo");
+            await jest.advanceTimersByTimeAsync(1000);
+            const result = await promise;
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            expect(result.status).toBe(200);
+        });
+
+        it("does not retry on a non-retryable 4xx", async () => {
+            const fetchMock = jest
+                .fn()
+                .mockResolvedValue(mockResponse(404, { message: "Not Found" }));
+            global.fetch = fetchMock;
+
+            const client = createRequestClient(
+                "https://api.github.com",
+                "test-token",
+            );
+
+            await expect(client("/repos/owner/repo")).rejects.toThrow(
+                GithubApiError,
+            );
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("throws after exhausting all 3 attempts", async () => {
+            jest.useFakeTimers();
+            const fetchMock = jest
+                .fn()
+                .mockResolvedValue(
+                    mockResponse(503, { message: "Service Unavailable" }),
+                );
+            global.fetch = fetchMock;
+
+            const client = createRequestClient(
+                "https://api.github.com",
+                "test-token",
+            );
+
+            const promise = client("/repos/owner/repo");
+            const assertion = expect(promise).rejects.toThrow(GithubApiError);
+            await jest.advanceTimersByTimeAsync(1000);
+            await jest.advanceTimersByTimeAsync(2000);
+            await assertion;
+
+            expect(fetchMock).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    describe("rate limiting", () => {
+        it("queues the next request until x-ratelimit-reset when remaining hits 0", async () => {
+            jest.useFakeTimers();
+            const resetEpochSeconds = Math.floor(Date.now() / 1000) + 5;
+            const fetchMock = jest
+                .fn()
+                .mockResolvedValueOnce(
+                    mockResponse(
+                        200,
+                        { ok: true },
+                        {
+                            "x-ratelimit-remaining": "0",
+                            "x-ratelimit-reset": String(resetEpochSeconds),
+                        },
+                    ),
+                )
+                .mockResolvedValueOnce(mockResponse(200, { ok: true }));
+            global.fetch = fetchMock;
+
+            const client = createRequestClient(
+                "https://api.github.com",
+                "test-token",
+            );
+
+            await client("/repos/owner/repo");
+
+            let secondResolved = false;
+            const secondPromise = client("/repos/owner/repo").then((r) => {
+                secondResolved = true;
+                return r;
+            });
+
+            await Promise.resolve();
+            expect(secondResolved).toBe(false);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+
+            await jest.advanceTimersByTimeAsync(5000);
+            await secondPromise;
+
+            expect(secondResolved).toBe(true);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+
+        it("does not wait when rate limit remaining is above 0", async () => {
+            const fetchMock = jest.fn().mockResolvedValue(
+                mockResponse(
+                    200,
+                    { ok: true },
+                    {
+                        "x-ratelimit-remaining": "10",
+                        "x-ratelimit-reset": String(
+                            Math.floor(Date.now() / 1000) + 3600,
+                        ),
+                    },
+                ),
+            );
+            global.fetch = fetchMock;
+
+            const client = createRequestClient(
+                "https://api.github.com",
+                "test-token",
+            );
+
+            await client("/repos/owner/repo");
+            await client("/repos/owner/repo");
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe("ETag caching", () => {
+        it("sends If-None-Match on a repeat GET and returns cached data on 304", async () => {
+            const fetchMock = jest
+                .fn()
+                .mockResolvedValueOnce(
+                    mockResponse(200, { id: 1 }, { etag: "abc123" }),
+                )
+                .mockResolvedValueOnce(mockResponse(304, null));
+            global.fetch = fetchMock;
+
+            const client = createRequestClient(
+                "https://api.github.com",
+                "test-token",
+            );
+
+            const first = await client("/repos/owner/repo");
+            expect(first.data).toEqual({ id: 1 });
+
+            const second = await client("/repos/owner/repo");
+            expect(second.status).toBe(304);
+            expect(second.data).toEqual({ id: 1 });
+
+            const secondCallHeaders = (
+                fetchMock.mock.calls[1][1] as {
+                    headers: Record<string, string>;
+                }
+            ).headers;
+            expect(secondCallHeaders["If-None-Match"]).toBe("abc123");
+        });
+
+        it("does not send If-None-Match for a POST request", async () => {
+            const fetchMock = jest
+                .fn()
+                .mockResolvedValueOnce(
+                    mockResponse(200, { id: 1 }, { etag: "abc123" }),
+                )
+                .mockResolvedValueOnce(mockResponse(201, { id: 2 }));
+            global.fetch = fetchMock;
+
+            const client = createRequestClient(
+                "https://api.github.com",
+                "test-token",
+            );
+
+            await client("/repos/owner/repo");
+            await client("/repos/owner/repo", { method: "POST" });
+
+            const secondCallHeaders = (
+                fetchMock.mock.calls[1][1] as {
+                    headers: Record<string, string>;
+                }
+            ).headers;
+            expect(secondCallHeaders["If-None-Match"]).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
Rewrote request<T> as a createRequestClient(baseUrl, token) factory so rate-limit state and the ETag cache live per GithubClient instance. Adds: proactive wait when x-ratelimit-remaining hits 0 (until x-ratelimit-reset), exponential-backoff retry on 5xx/429 (3 attempts, 1s/2s/4s), and If-None-Match/304 ETag caching on repeat GETs. Also fixed two bugs found while rewriting: response.json() was throwing on empty bodies like the 204 from isMerged(), and GithubApiError accepted documentationUrl/details but never received them. 11 new unit tests (35 total passing), build clean.

Closes: #43, #44, #45