### PR TITLE
Add Issues module (closes #47)

### DIFF
--- a/src/client/GithubClient.ts
+++ b/src/client/GithubClient.ts
@@ -1,3 +1,4 @@
+import { IssueService } from "../modules/issues/IssueService";
 import { PullRequestService } from "../modules/pull-requests/PullRequestService";
 import { RepositoryService } from "../modules/repositories/RepositoryService";
 import { UserService } from "../modules/users/UserService";
@@ -23,6 +24,7 @@ export class GithubClient {
     public readonly pullRequests: PullRequestService;
     public readonly users: UserService;
     public readonly repositories: RepositoryService;
+    public readonly issues: IssueService;
     public readonly baseUrl: string;
     private readonly requestClient: RequestClient;
 
@@ -46,6 +48,7 @@ export class GithubClient {
         this.pullRequests = new PullRequestService(this);
         this.users = new UserService(this);
         this.repositories = new RepositoryService(this);
+        this.issues = new IssueService(this);
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { GithubClient } from "./client/GithubClient";
 
 export * from "./modules/commits/commit.types";
+export * from "./modules/issues/issue.types";
 export * from "./modules/pull-requests/pull-request.types";
 export * from "./modules/repositories/repository.types";
 export * from "./modules/users/user.types";

--- a/src/modules/issues/IssueService.ts
+++ b/src/modules/issues/IssueService.ts
@@ -1,0 +1,156 @@
+import { GithubClient } from "../../client/GithubClient";
+import {
+    Issue,
+    IssueComment,
+    CreateIssueParams,
+    UpdateIssueParams,
+} from "./issue.types";
+import { IssueDTO, IssueCommentDTO } from "./issue.dto";
+import {
+    mapCreateIssueParams,
+    mapIssue,
+    mapIssueComment,
+    mapIssueComments,
+    mapIssues,
+    mapUpdateIssueParams,
+} from "./issue.mapper";
+import { assertConfig } from "../../shared/utils/config.utils";
+
+export class IssueService {
+    private readonly path: string;
+
+    constructor(private readonly client: GithubClient) {
+        assertConfig(this.client, ["owner", "repo"]);
+        this.path = `/repos/${this.client.config.owner}/${this.client.config.repo}/issues`;
+    }
+
+    /**
+     * List issues of a repository. Note: GitHub models pull requests as
+     * issues, so this may include them — check `isPullRequest` on each
+     * result to filter them out if needed.
+     *
+     * @returns Array of issues
+     *
+     * @example
+     * ```ts
+     * const issues = await github.issues.list();
+     * ```
+     */
+    public async list(): Promise<Issue[]> {
+        const response = await this.client.request<IssueDTO[]>(this.path);
+        return mapIssues(response.data);
+    }
+
+    /**
+     * Get details of an issue by providing its number
+     *
+     * @param issueNumber The number that identifies the issue
+     * @returns Data of an issue
+     *
+     * @example
+     * ```ts
+     * const issue = await github.issues.get(12);
+     * ```
+     */
+    public async get(issueNumber: number): Promise<Issue> {
+        const response = await this.client.request<IssueDTO>(
+            `${this.path}/${issueNumber}`,
+        );
+        return mapIssue(response.data);
+    }
+
+    /**
+     * Create an issue
+     *
+     * @param params Configuration for the issue
+     * @returns Data of the created issue
+     *
+     * @example
+     * ```ts
+     * github.issues.create({
+     *     title: 'Bug: build fails on Node 22',
+     *     body: 'Steps to reproduce...',
+     *     labels: ['bug'],
+     * });
+     * ```
+     */
+    public async create(params: CreateIssueParams): Promise<Issue> {
+        const body = mapCreateIssueParams(params);
+        const response = await this.client.request<IssueDTO>(this.path, {
+            method: "POST",
+            body: JSON.stringify(body),
+        });
+        return mapIssue(response.data);
+    }
+
+    /**
+     * Update an issue
+     *
+     * @param params Configuration for the issue to update
+     * @returns Data of the updated issue
+     *
+     * @example
+     * ```ts
+     * github.issues.update({
+     *     issueNumber: 12,
+     *     state: 'closed',
+     *     stateReason: 'completed',
+     * });
+     * ```
+     */
+    public async update(params: UpdateIssueParams): Promise<Issue> {
+        const body = mapUpdateIssueParams(params);
+        const response = await this.client.request<IssueDTO>(
+            `${this.path}/${params.issueNumber}`,
+            {
+                method: "PATCH",
+                body: JSON.stringify(body),
+            },
+        );
+        return mapIssue(response.data);
+    }
+
+    /**
+     * List comments on an issue
+     *
+     * @param issueNumber The number that identifies the issue
+     * @returns Array of issue comments
+     *
+     * @example
+     * ```ts
+     * const comments = await github.issues.listComments(12);
+     * ```
+     */
+    public async listComments(issueNumber: number): Promise<IssueComment[]> {
+        const response = await this.client.request<IssueCommentDTO[]>(
+            `${this.path}/${issueNumber}/comments`,
+        );
+        return mapIssueComments(response.data);
+    }
+
+    /**
+     * Add a comment to an issue
+     *
+     * @param issueNumber The number that identifies the issue
+     * @param body The comment text
+     * @returns Data of the created comment
+     *
+     * @example
+     * ```ts
+     * github.issues.addComment(12, 'Thanks for the report!');
+     * ```
+     */
+    public async addComment(
+        issueNumber: number,
+        body: string,
+    ): Promise<IssueComment> {
+        const response = await this.client.request<IssueCommentDTO>(
+            `${this.path}/${issueNumber}/comments`,
+            {
+                method: "POST",
+                body: JSON.stringify({ body }),
+            },
+        );
+        return mapIssueComment(response.data);
+    }
+}

--- a/src/modules/issues/issue.dto.ts
+++ b/src/modules/issues/issue.dto.ts
@@ -1,0 +1,65 @@
+import { IssueState, IssueStateReason } from "./issue.types";
+import { UserDTO } from "../users/user.dto";
+
+export interface LabelDTO {
+    id: number;
+    node_id: string;
+    name: string;
+    description: string | null;
+    color: string;
+    default: boolean;
+}
+
+export interface MilestoneDTO {
+    id: number;
+    node_id: string;
+    number: number;
+    title: string;
+    description: string | null;
+    state: "open" | "closed";
+    created_at: string;
+    updated_at: string;
+    closed_at: string | null;
+    due_on: string | null;
+}
+
+export interface IssuePullRequestRefDTO {
+    url: string;
+    html_url: string;
+    diff_url: string | null;
+    patch_url: string | null;
+}
+
+export interface IssueDTO {
+    id: number;
+    node_id: string;
+    number: number;
+    title: string;
+    body: string | null;
+    state: IssueState;
+    state_reason: IssueStateReason;
+    user: UserDTO;
+    labels: LabelDTO[];
+    assignee: UserDTO | null;
+    assignees: UserDTO[];
+    milestone: MilestoneDTO | null;
+    comments: number;
+    locked: boolean;
+    html_url: string;
+    url: string;
+    created_at: string;
+    updated_at: string;
+    closed_at: string | null;
+    pull_request?: IssuePullRequestRefDTO;
+}
+
+export interface IssueCommentDTO {
+    id: number;
+    node_id: string;
+    user: UserDTO;
+    body: string;
+    html_url: string;
+    url: string;
+    created_at: string;
+    updated_at: string;
+}

--- a/src/modules/issues/issue.mapper.ts
+++ b/src/modules/issues/issue.mapper.ts
@@ -1,0 +1,114 @@
+import {
+    Issue,
+    IssueComment,
+    Label,
+    Milestone,
+    CreateIssueParams,
+    CreateIssuePayload,
+    UpdateIssueParams,
+    UpdateIssuePayload,
+} from "./issue.types";
+import { IssueDTO, IssueCommentDTO, LabelDTO, MilestoneDTO } from "./issue.dto";
+import { mapUser } from "../users/user.mapper";
+
+export function mapLabel(dto: LabelDTO): Label {
+    return {
+        id: dto.id,
+        nodeId: dto.node_id,
+        name: dto.name,
+        description: dto.description,
+        color: dto.color,
+        isDefault: dto.default,
+    };
+}
+
+export function mapLabels(dtos: LabelDTO[]): Label[] {
+    return dtos.map((dto) => mapLabel(dto));
+}
+
+export function mapMilestone(dto: MilestoneDTO): Milestone {
+    return {
+        id: dto.id,
+        nodeId: dto.node_id,
+        number: dto.number,
+        title: dto.title,
+        description: dto.description,
+        state: dto.state,
+        createdAt: dto.created_at,
+        updatedAt: dto.updated_at,
+        closedAt: dto.closed_at,
+        dueOn: dto.due_on,
+    };
+}
+
+export function mapIssue(dto: IssueDTO): Issue {
+    return {
+        id: dto.id,
+        nodeId: dto.node_id,
+        number: dto.number,
+        title: dto.title,
+        body: dto.body,
+        state: dto.state,
+        stateReason: dto.state_reason,
+        user: mapUser(dto.user),
+        labels: mapLabels(dto.labels),
+        assignee: dto.assignee ? mapUser(dto.assignee) : null,
+        assignees: dto.assignees.map((assignee) => mapUser(assignee)),
+        milestone: dto.milestone ? mapMilestone(dto.milestone) : null,
+        comments: dto.comments,
+        isLocked: dto.locked,
+        url: dto.html_url,
+        apiUrl: dto.url,
+        createdAt: dto.created_at,
+        updatedAt: dto.updated_at,
+        closedAt: dto.closed_at,
+        isPullRequest: dto.pull_request !== undefined,
+    };
+}
+
+export function mapIssues(dtos: IssueDTO[]): Issue[] {
+    return dtos.map((dto) => mapIssue(dto));
+}
+
+export function mapIssueComment(dto: IssueCommentDTO): IssueComment {
+    return {
+        id: dto.id,
+        nodeId: dto.node_id,
+        user: mapUser(dto.user),
+        body: dto.body,
+        url: dto.html_url,
+        apiUrl: dto.url,
+        createdAt: dto.created_at,
+        updatedAt: dto.updated_at,
+    };
+}
+
+export function mapIssueComments(dtos: IssueCommentDTO[]): IssueComment[] {
+    return dtos.map((dto) => mapIssueComment(dto));
+}
+
+export function mapCreateIssueParams(
+    params: CreateIssueParams,
+): CreateIssuePayload {
+    return {
+        title: params.title,
+        body: params.body,
+        labels: params.labels,
+        assignees: params.assignees,
+        milestone: params.milestone,
+    };
+}
+
+export function mapUpdateIssueParams(
+    params: UpdateIssueParams,
+): UpdateIssuePayload {
+    return {
+        title: params.title,
+        body: params.body,
+        state: params.state,
+        state_reason: params.stateReason,
+        labels: params.labels,
+        assignees: params.assignees,
+        milestone: params.milestone,
+    };
+}

--- a/src/modules/issues/issue.types.ts
+++ b/src/modules/issues/issue.types.ts
@@ -1,0 +1,98 @@
+import { User } from "../users/user.types";
+
+export type IssueState = "open" | "closed";
+export type IssueStateReason = "completed" | "reopened" | "not_planned" | null;
+
+export interface Label {
+    id: number;
+    nodeId: string;
+    name: string;
+    description: string | null;
+    color: string;
+    isDefault: boolean;
+}
+
+export interface Milestone {
+    id: number;
+    nodeId: string;
+    number: number;
+    title: string;
+    description: string | null;
+    state: "open" | "closed";
+    createdAt: string;
+    updatedAt: string;
+    closedAt: string | null;
+    dueOn: string | null;
+}
+
+export interface Issue {
+    id: number;
+    nodeId: string;
+    number: number;
+    title: string;
+    body: string | null;
+    state: IssueState;
+    stateReason: IssueStateReason;
+    user: User;
+    labels: Label[];
+    assignee: User | null;
+    assignees: User[];
+    milestone: Milestone | null;
+    comments: number;
+    isLocked: boolean;
+    url: string;
+    apiUrl: string;
+    createdAt: string;
+    updatedAt: string;
+    closedAt: string | null;
+    /** True if this issue is actually a pull request (GitHub models PRs as issues). */
+    isPullRequest: boolean;
+}
+
+export interface IssueComment {
+    id: number;
+    nodeId: string;
+    user: User;
+    body: string;
+    url: string;
+    apiUrl: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface CreateIssueParams {
+    title: string;
+    body?: string;
+    labels?: string[];
+    assignees?: string[];
+    milestone?: number;
+}
+
+export interface CreateIssuePayload {
+    title: string;
+    body?: string;
+    labels?: string[];
+    assignees?: string[];
+    milestone?: number;
+}
+
+export interface UpdateIssueParams {
+    issueNumber: number;
+    title?: string;
+    body?: string;
+    state?: IssueState;
+    stateReason?: IssueStateReason;
+    labels?: string[];
+    assignees?: string[];
+    milestone?: number | null;
+}
+
+export interface UpdateIssuePayload {
+    title?: string;
+    body?: string;
+    state?: IssueState;
+    state_reason?: IssueStateReason;
+    labels?: string[];
+    assignees?: string[];
+    milestone?: number | null;
+}

--- a/tests/unit/modules/issues/IssueService.test.ts
+++ b/tests/unit/modules/issues/IssueService.test.ts
@@ -1,0 +1,169 @@
+import { GithubClient } from "../../../../src/client/GithubClient";
+import { IssueService } from "../../../../src/modules/issues/IssueService";
+import { IssueDTO } from "../../../../src/modules/issues/issue.dto";
+import { UserDTO } from "../../../../src/modules/users/user.dto";
+
+const mockUserDto: UserDTO = {
+    login: "testuser",
+    id: 1,
+    node_id: "U_1",
+    avatar_url: "",
+    html_url: "",
+    url: "",
+    type: "User",
+    site_admin: false,
+    name: null,
+    company: null,
+    blog: null,
+    location: null,
+    email: null,
+    bio: null,
+    twitter_username: null,
+    public_repos: 0,
+    public_gists: 0,
+    followers: 0,
+    following: 0,
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2020-01-01T00:00:00Z",
+};
+
+const mockIssueDto: IssueDTO = {
+    id: 1,
+    node_id: "I_1",
+    number: 12,
+    title: "Bug: build fails",
+    body: "Steps to reproduce...",
+    state: "open",
+    state_reason: null,
+    user: mockUserDto,
+    labels: [],
+    assignee: null,
+    assignees: [],
+    milestone: null,
+    comments: 0,
+    locked: false,
+    html_url: "https://github.com/owner/repo/issues/12",
+    url: "https://api.github.com/repos/owner/repo/issues/12",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    closed_at: null,
+};
+
+function makeService() {
+    const mockRequest = jest.fn();
+    const client = {
+        config: { token: "test-token", owner: "test-owner", repo: "test-repo" },
+        request: mockRequest,
+        baseUrl: "https://api.github.com",
+    } as unknown as GithubClient;
+    return { service: new IssueService(client), mockRequest };
+}
+
+describe("IssueService", () => {
+    describe("list", () => {
+        it("calls GET /repos/:owner/:repo/issues", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: [mockIssueDto],
+                status: 200,
+            });
+            await service.list();
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/issues",
+            );
+        });
+
+        it("returns an array of mapped Issues", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: [mockIssueDto],
+                status: 200,
+            });
+            const result = await service.list();
+            expect(result[0].number).toBe(12);
+        });
+    });
+
+    describe("get", () => {
+        it("calls GET /repos/:owner/:repo/issues/:number", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: mockIssueDto, status: 200 });
+            await service.get(12);
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/issues/12",
+            );
+        });
+    });
+
+    describe("create", () => {
+        it("calls POST /repos/:owner/:repo/issues with the mapped payload", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: mockIssueDto, status: 201 });
+            await service.create({ title: "New bug", labels: ["bug"] });
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/issues",
+                {
+                    method: "POST",
+                    body: JSON.stringify({
+                        title: "New bug",
+                        body: undefined,
+                        labels: ["bug"],
+                        assignees: undefined,
+                        milestone: undefined,
+                    }),
+                },
+            );
+        });
+    });
+
+    describe("update", () => {
+        it("calls PATCH /repos/:owner/:repo/issues/:number with the mapped payload", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: { ...mockIssueDto, state: "closed" },
+                status: 200,
+            });
+            await service.update({ issueNumber: 12, state: "closed" });
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/issues/12",
+                expect.objectContaining({ method: "PATCH" }),
+            );
+        });
+    });
+
+    describe("listComments", () => {
+        it("calls GET /repos/:owner/:repo/issues/:number/comments", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: [], status: 200 });
+            await service.listComments(12);
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/issues/12/comments",
+            );
+        });
+    });
+
+    describe("addComment", () => {
+        it("calls POST /repos/:owner/:repo/issues/:number/comments with the body", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: {
+                    id: 1,
+                    node_id: "IC_1",
+                    user: mockUserDto,
+                    body: "Thanks!",
+                    html_url: "",
+                    url: "",
+                    created_at: "2024-01-01T00:00:00Z",
+                    updated_at: "2024-01-01T00:00:00Z",
+                },
+                status: 201,
+            });
+            const result = await service.addComment(12, "Thanks!");
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/issues/12/comments",
+                { method: "POST", body: JSON.stringify({ body: "Thanks!" }) },
+            );
+            expect(result.body).toBe("Thanks!");
+        });
+    });
+});

--- a/tests/unit/modules/issues/issue.mapper.test.ts
+++ b/tests/unit/modules/issues/issue.mapper.test.ts
@@ -1,0 +1,193 @@
+import {
+    mapIssue,
+    mapIssues,
+    mapIssueComment,
+    mapLabel,
+    mapMilestone,
+    mapCreateIssueParams,
+    mapUpdateIssueParams,
+} from "../../../../src/modules/issues/issue.mapper";
+import {
+    IssueDTO,
+    IssueCommentDTO,
+    LabelDTO,
+    MilestoneDTO,
+} from "../../../../src/modules/issues/issue.dto";
+import { UserDTO } from "../../../../src/modules/users/user.dto";
+
+const mockUserDto: UserDTO = {
+    login: "testuser",
+    id: 1,
+    node_id: "U_1",
+    avatar_url: "",
+    html_url: "",
+    url: "",
+    type: "User",
+    site_admin: false,
+    name: null,
+    company: null,
+    blog: null,
+    location: null,
+    email: null,
+    bio: null,
+    twitter_username: null,
+    public_repos: 0,
+    public_gists: 0,
+    followers: 0,
+    following: 0,
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2020-01-01T00:00:00Z",
+};
+
+const mockLabelDto: LabelDTO = {
+    id: 1,
+    node_id: "L_1",
+    name: "bug",
+    description: "Something isn't working",
+    color: "d73a4a",
+    default: true,
+};
+
+const mockMilestoneDto: MilestoneDTO = {
+    id: 1,
+    node_id: "M_1",
+    number: 1,
+    title: "v1",
+    description: null,
+    state: "open",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    closed_at: null,
+    due_on: null,
+};
+
+const mockIssueDto: IssueDTO = {
+    id: 1,
+    node_id: "I_1",
+    number: 12,
+    title: "Bug: build fails",
+    body: "Steps to reproduce...",
+    state: "open",
+    state_reason: null,
+    user: mockUserDto,
+    labels: [mockLabelDto],
+    assignee: null,
+    assignees: [],
+    milestone: null,
+    comments: 0,
+    locked: false,
+    html_url: "https://github.com/owner/repo/issues/12",
+    url: "https://api.github.com/repos/owner/repo/issues/12",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    closed_at: null,
+};
+
+describe("issue.mapper", () => {
+    describe("mapLabel", () => {
+        it("maps default to isDefault", () => {
+            const result = mapLabel(mockLabelDto);
+            expect(result.isDefault).toBe(true);
+            expect(result.name).toBe("bug");
+        });
+    });
+
+    describe("mapMilestone", () => {
+        it("maps snake_case fields to camelCase", () => {
+            const result = mapMilestone(mockMilestoneDto);
+            expect(result.dueOn).toBeNull();
+            expect(result.createdAt).toBe("2024-01-01T00:00:00Z");
+        });
+    });
+
+    describe("mapIssue", () => {
+        it("maps a plain issue with isPullRequest false", () => {
+            const result = mapIssue(mockIssueDto);
+            expect(result.number).toBe(12);
+            expect(result.isPullRequest).toBe(false);
+            expect(result.labels[0].name).toBe("bug");
+            expect(result.assignee).toBeNull();
+            expect(result.milestone).toBeNull();
+        });
+
+        it("sets isPullRequest true when pull_request is present", () => {
+            const result = mapIssue({
+                ...mockIssueDto,
+                pull_request: {
+                    url: "https://api.github.com/repos/owner/repo/pulls/12",
+                    html_url: "https://github.com/owner/repo/pull/12",
+                    diff_url: null,
+                    patch_url: null,
+                },
+            });
+            expect(result.isPullRequest).toBe(true);
+        });
+
+        it("maps assignee and milestone when present", () => {
+            const result = mapIssue({
+                ...mockIssueDto,
+                assignee: mockUserDto,
+                assignees: [mockUserDto],
+                milestone: mockMilestoneDto,
+            });
+            expect(result.assignee?.username).toBe("testuser");
+            expect(result.assignees).toHaveLength(1);
+            expect(result.milestone?.title).toBe("v1");
+        });
+    });
+
+    describe("mapIssues", () => {
+        it("maps an array of issues", () => {
+            const result = mapIssues([mockIssueDto]);
+            expect(result).toHaveLength(1);
+        });
+    });
+
+    describe("mapIssueComment", () => {
+        it("maps a comment DTO to camelCase", () => {
+            const dto: IssueCommentDTO = {
+                id: 1,
+                node_id: "IC_1",
+                user: mockUserDto,
+                body: "Thanks for the report!",
+                html_url:
+                    "https://github.com/owner/repo/issues/12#issuecomment-1",
+                url: "https://api.github.com/repos/owner/repo/issues/comments/1",
+                created_at: "2024-01-01T00:00:00Z",
+                updated_at: "2024-01-01T00:00:00Z",
+            };
+            const result = mapIssueComment(dto);
+            expect(result.body).toBe("Thanks for the report!");
+            expect(result.user.username).toBe("testuser");
+        });
+    });
+
+    describe("mapCreateIssueParams", () => {
+        it("passes params through unchanged (already flat)", () => {
+            const result = mapCreateIssueParams({
+                title: "New bug",
+                labels: ["bug"],
+                assignees: ["testuser"],
+            });
+            expect(result).toEqual({
+                title: "New bug",
+                body: undefined,
+                labels: ["bug"],
+                assignees: ["testuser"],
+                milestone: undefined,
+            });
+        });
+    });
+
+    describe("mapUpdateIssueParams", () => {
+        it("maps stateReason to state_reason", () => {
+            const result = mapUpdateIssueParams({
+                issueNumber: 12,
+                state: "closed",
+                stateReason: "completed",
+            });
+            expect(result.state).toBe("closed");
+            expect(result.state_reason).toBe("completed");
+        });
+    });
+});


### PR DESCRIPTION
Follows the four-file pattern: issue.types.ts, issue.dto.ts, issue.mapper.ts, IssueService.ts. Wired into GithubClient as github.issues.

 New modules/issues/ following the standard four-file pattern, wired into GithubClient as github.issues. Methods: list(), get(), create(), update(), listComments(), addComment(). One design note: since GitHub models pull requests as issues under the hood, Issue exposes an isPullRequest flag rather than silently filtering PRs out of list() — matches raw API semantics rather than introducing surprising magic behavior. 27 new unit tests (mapper + service), 51 total passing, build clean.
 
 closes #47 