### PR TITLE
Add Releases module (closes #48)

### DIFF
--- a/src/client/GithubClient.ts
+++ b/src/client/GithubClient.ts
@@ -1,5 +1,6 @@
 import { IssueService } from "../modules/issues/IssueService";
 import { PullRequestService } from "../modules/pull-requests/PullRequestService";
+import { ReleaseService } from "../modules/releases/ReleaseService";
 import { RepositoryService } from "../modules/repositories/RepositoryService";
 import { UserService } from "../modules/users/UserService";
 import {
@@ -25,6 +26,7 @@ export class GithubClient {
     public readonly users: UserService;
     public readonly repositories: RepositoryService;
     public readonly issues: IssueService;
+    public readonly releases: ReleaseService;
     public readonly baseUrl: string;
     private readonly requestClient: RequestClient;
 
@@ -49,6 +51,7 @@ export class GithubClient {
         this.users = new UserService(this);
         this.repositories = new RepositoryService(this);
         this.issues = new IssueService(this);
+        this.releases = new ReleaseService(this);
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { GithubClient } from "./client/GithubClient";
 export * from "./modules/commits/commit.types";
 export * from "./modules/issues/issue.types";
 export * from "./modules/pull-requests/pull-request.types";
+export * from "./modules/releases/release.types";
 export * from "./modules/repositories/repository.types";
 export * from "./modules/users/user.types";
 

--- a/src/modules/releases/ReleaseService.ts
+++ b/src/modules/releases/ReleaseService.ts
@@ -1,0 +1,157 @@
+import { GithubClient } from "../../client/GithubClient";
+import {
+    Release,
+    CreateReleaseParams,
+    UpdateReleaseParams,
+} from "./release.types";
+import { ReleaseDTO } from "./release.dto";
+import {
+    mapCreateReleaseParams,
+    mapRelease,
+    mapReleases,
+    mapUpdateReleaseParams,
+} from "./release.mapper";
+import { assertConfig } from "../../shared/utils/config.utils";
+
+export class ReleaseService {
+    private readonly path: string;
+
+    constructor(private readonly client: GithubClient) {
+        assertConfig(this.client, ["owner", "repo"]);
+        this.path = `/repos/${this.client.config.owner}/${this.client.config.repo}/releases`;
+    }
+
+    /**
+     * List releases of a repository
+     *
+     * @returns Array of releases
+     *
+     * @example
+     * ```ts
+     * const releases = await github.releases.list();
+     * ```
+     */
+    public async list(): Promise<Release[]> {
+        const response = await this.client.request<ReleaseDTO[]>(this.path);
+        return mapReleases(response.data);
+    }
+
+    /**
+     * Get a release by its ID
+     *
+     * @param releaseId The ID that identifies the release
+     * @returns Data of a release
+     *
+     * @example
+     * ```ts
+     * const release = await github.releases.get(12345);
+     * ```
+     */
+    public async get(releaseId: number): Promise<Release> {
+        const response = await this.client.request<ReleaseDTO>(
+            `${this.path}/${releaseId}`,
+        );
+        return mapRelease(response.data);
+    }
+
+    /**
+     * Get the latest published release, ignoring drafts and prereleases
+     *
+     * @returns Data of the latest release
+     *
+     * @example
+     * ```ts
+     * const latest = await github.releases.getLatest();
+     * ```
+     */
+    public async getLatest(): Promise<Release> {
+        const response = await this.client.request<ReleaseDTO>(
+            `${this.path}/latest`,
+        );
+        return mapRelease(response.data);
+    }
+
+    /**
+     * Get a release by its tag name
+     *
+     * @param tag The tag name that identifies the release
+     * @returns Data of a release
+     *
+     * @example
+     * ```ts
+     * const release = await github.releases.getByTag('v1.0.0');
+     * ```
+     */
+    public async getByTag(tag: string): Promise<Release> {
+        const response = await this.client.request<ReleaseDTO>(
+            `${this.path}/tags/${tag}`,
+        );
+        return mapRelease(response.data);
+    }
+
+    /**
+     * Create a release
+     *
+     * @param params Configuration for the release
+     * @returns Data of the created release
+     *
+     * @example
+     * ```ts
+     * github.releases.create({
+     *     tagName: 'v1.0.0',
+     *     name: 'v1.0.0',
+     *     body: 'Initial release',
+     * });
+     * ```
+     */
+    public async create(params: CreateReleaseParams): Promise<Release> {
+        const body = mapCreateReleaseParams(params);
+        const response = await this.client.request<ReleaseDTO>(this.path, {
+            method: "POST",
+            body: JSON.stringify(body),
+        });
+        return mapRelease(response.data);
+    }
+
+    /**
+     * Update a release
+     *
+     * @param params Configuration for the release to update
+     * @returns Data of the updated release
+     *
+     * @example
+     * ```ts
+     * github.releases.update({
+     *     releaseId: 12345,
+     *     body: 'Updated release notes',
+     * });
+     * ```
+     */
+    public async update(params: UpdateReleaseParams): Promise<Release> {
+        const body = mapUpdateReleaseParams(params);
+        const response = await this.client.request<ReleaseDTO>(
+            `${this.path}/${params.releaseId}`,
+            {
+                method: "PATCH",
+                body: JSON.stringify(body),
+            },
+        );
+        return mapRelease(response.data);
+    }
+
+    /**
+     * Delete a release
+     *
+     * @param releaseId The ID that identifies the release
+     *
+     * @example
+     * ```ts
+     * await github.releases.delete(12345);
+     * ```
+     */
+    public async delete(releaseId: number): Promise<void> {
+        await this.client.request<null>(`${this.path}/${releaseId}`, {
+            method: "DELETE",
+        });
+    }
+}

--- a/src/modules/releases/release.dto.ts
+++ b/src/modules/releases/release.dto.ts
@@ -1,0 +1,34 @@
+import { UserDTO } from "../users/user.dto";
+
+export interface ReleaseAssetDTO {
+    id: number;
+    node_id: string;
+    name: string;
+    label: string | null;
+    content_type: string;
+    size: number;
+    download_count: number;
+    url: string;
+    browser_download_url: string;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface ReleaseDTO {
+    id: number;
+    node_id: string;
+    tag_name: string;
+    target_commitish: string;
+    name: string | null;
+    body: string | null;
+    draft: boolean;
+    prerelease: boolean;
+    author: UserDTO;
+    assets: ReleaseAssetDTO[];
+    html_url: string;
+    url: string;
+    tarball_url: string | null;
+    zipball_url: string | null;
+    created_at: string;
+    published_at: string | null;
+}

--- a/src/modules/releases/release.mapper.ts
+++ b/src/modules/releases/release.mapper.ts
@@ -1,0 +1,82 @@
+import {
+    Release,
+    ReleaseAsset,
+    CreateReleaseParams,
+    CreateReleasePayload,
+    UpdateReleaseParams,
+    UpdateReleasePayload,
+} from "./release.types";
+import { ReleaseDTO, ReleaseAssetDTO } from "./release.dto";
+import { mapUser } from "../users/user.mapper";
+
+export function mapReleaseAsset(dto: ReleaseAssetDTO): ReleaseAsset {
+    return {
+        id: dto.id,
+        nodeId: dto.node_id,
+        name: dto.name,
+        label: dto.label,
+        contentType: dto.content_type,
+        size: dto.size,
+        downloadCount: dto.download_count,
+        url: dto.url,
+        downloadUrl: dto.browser_download_url,
+        createdAt: dto.created_at,
+        updatedAt: dto.updated_at,
+    };
+}
+
+export function mapReleaseAssets(dtos: ReleaseAssetDTO[]): ReleaseAsset[] {
+    return dtos.map((dto) => mapReleaseAsset(dto));
+}
+
+export function mapRelease(dto: ReleaseDTO): Release {
+    return {
+        id: dto.id,
+        nodeId: dto.node_id,
+        tagName: dto.tag_name,
+        targetCommitish: dto.target_commitish,
+        name: dto.name,
+        body: dto.body,
+        isDraft: dto.draft,
+        isPrerelease: dto.prerelease,
+        author: mapUser(dto.author),
+        assets: mapReleaseAssets(dto.assets),
+        url: dto.html_url,
+        apiUrl: dto.url,
+        tarballUrl: dto.tarball_url,
+        zipballUrl: dto.zipball_url,
+        createdAt: dto.created_at,
+        publishedAt: dto.published_at,
+    };
+}
+
+export function mapReleases(dtos: ReleaseDTO[]): Release[] {
+    return dtos.map((dto) => mapRelease(dto));
+}
+
+export function mapCreateReleaseParams(
+    params: CreateReleaseParams,
+): CreateReleasePayload {
+    return {
+        tag_name: params.tagName,
+        target_commitish: params.targetCommitish,
+        name: params.name,
+        body: params.body,
+        draft: params.draft,
+        prerelease: params.prerelease,
+        generate_release_notes: params.generateReleaseNotes,
+    };
+}
+
+export function mapUpdateReleaseParams(
+    params: UpdateReleaseParams,
+): UpdateReleasePayload {
+    return {
+        tag_name: params.tagName,
+        target_commitish: params.targetCommitish,
+        name: params.name,
+        body: params.body,
+        draft: params.draft,
+        prerelease: params.prerelease,
+    };
+}

--- a/src/modules/releases/release.types.ts
+++ b/src/modules/releases/release.types.ts
@@ -1,0 +1,73 @@
+import { User } from "../users/user.types";
+
+export interface ReleaseAsset {
+    id: number;
+    nodeId: string;
+    name: string;
+    label: string | null;
+    contentType: string;
+    size: number;
+    downloadCount: number;
+    url: string;
+    downloadUrl: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface Release {
+    id: number;
+    nodeId: string;
+    tagName: string;
+    targetCommitish: string;
+    name: string | null;
+    body: string | null;
+    isDraft: boolean;
+    isPrerelease: boolean;
+    author: User;
+    assets: ReleaseAsset[];
+    url: string;
+    apiUrl: string;
+    tarballUrl: string | null;
+    zipballUrl: string | null;
+    createdAt: string;
+    publishedAt: string | null;
+}
+
+export interface CreateReleaseParams {
+    tagName: string;
+    targetCommitish?: string;
+    name?: string;
+    body?: string;
+    draft?: boolean;
+    prerelease?: boolean;
+    generateReleaseNotes?: boolean;
+}
+
+export interface CreateReleasePayload {
+    tag_name: string;
+    target_commitish?: string;
+    name?: string;
+    body?: string;
+    draft?: boolean;
+    prerelease?: boolean;
+    generate_release_notes?: boolean;
+}
+
+export interface UpdateReleaseParams {
+    releaseId: number;
+    tagName?: string;
+    targetCommitish?: string;
+    name?: string;
+    body?: string;
+    draft?: boolean;
+    prerelease?: boolean;
+}
+
+export interface UpdateReleasePayload {
+    tag_name?: string;
+    target_commitish?: string;
+    name?: string;
+    body?: string;
+    draft?: boolean;
+    prerelease?: boolean;
+}

--- a/tests/unit/modules/releases/ReleaseService.test.ts
+++ b/tests/unit/modules/releases/ReleaseService.test.ts
@@ -1,0 +1,161 @@
+import { GithubClient } from "../../../../src/client/GithubClient";
+import { ReleaseService } from "../../../../src/modules/releases/ReleaseService";
+import { ReleaseDTO } from "../../../../src/modules/releases/release.dto";
+import { UserDTO } from "../../../../src/modules/users/user.dto";
+
+const mockUserDto: UserDTO = {
+    login: "testuser",
+    id: 1,
+    node_id: "U_1",
+    avatar_url: "",
+    html_url: "",
+    url: "",
+    type: "User",
+    site_admin: false,
+    name: null,
+    company: null,
+    blog: null,
+    location: null,
+    email: null,
+    bio: null,
+    twitter_username: null,
+    public_repos: 0,
+    public_gists: 0,
+    followers: 0,
+    following: 0,
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2020-01-01T00:00:00Z",
+};
+
+const mockReleaseDto: ReleaseDTO = {
+    id: 1,
+    node_id: "R_1",
+    tag_name: "v1.0.0",
+    target_commitish: "main",
+    name: "v1.0.0",
+    body: "Initial release",
+    draft: false,
+    prerelease: false,
+    author: mockUserDto,
+    assets: [],
+    html_url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+    url: "https://api.github.com/repos/owner/repo/releases/1",
+    tarball_url: null,
+    zipball_url: null,
+    created_at: "2024-01-01T00:00:00Z",
+    published_at: "2024-01-02T00:00:00Z",
+};
+
+function makeService() {
+    const mockRequest = jest.fn();
+    const client = {
+        config: { token: "test-token", owner: "test-owner", repo: "test-repo" },
+        request: mockRequest,
+        baseUrl: "https://api.github.com",
+    } as unknown as GithubClient;
+    return { service: new ReleaseService(client), mockRequest };
+}
+
+describe("ReleaseService", () => {
+    describe("list", () => {
+        it("calls GET /repos/:owner/:repo/releases", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: [mockReleaseDto],
+                status: 200,
+            });
+            await service.list();
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/releases",
+            );
+        });
+    });
+
+    describe("get", () => {
+        it("calls GET /repos/:owner/:repo/releases/:id", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: mockReleaseDto,
+                status: 200,
+            });
+            await service.get(1);
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/releases/1",
+            );
+        });
+    });
+
+    describe("getLatest", () => {
+        it("calls GET /repos/:owner/:repo/releases/latest", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: mockReleaseDto,
+                status: 200,
+            });
+            await service.getLatest();
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/releases/latest",
+            );
+        });
+    });
+
+    describe("getByTag", () => {
+        it("calls GET /repos/:owner/:repo/releases/tags/:tag", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: mockReleaseDto,
+                status: 200,
+            });
+            await service.getByTag("v1.0.0");
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/releases/tags/v1.0.0",
+            );
+        });
+    });
+
+    describe("create", () => {
+        it("calls POST /repos/:owner/:repo/releases with the mapped payload", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: mockReleaseDto,
+                status: 201,
+            });
+            await service.create({ tagName: "v1.0.0", name: "v1.0.0" });
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/releases",
+                expect.objectContaining({ method: "POST" }),
+            );
+            const callBody = JSON.parse(
+                (mockRequest.mock.calls[0][1] as { body: string }).body,
+            );
+            expect(callBody.tag_name).toBe("v1.0.0");
+        });
+    });
+
+    describe("update", () => {
+        it("calls PATCH /repos/:owner/:repo/releases/:id with the mapped payload", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: mockReleaseDto,
+                status: 200,
+            });
+            await service.update({ releaseId: 1, body: "Updated notes" });
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/releases/1",
+                expect.objectContaining({ method: "PATCH" }),
+            );
+        });
+    });
+
+    describe("delete", () => {
+        it("calls DELETE /repos/:owner/:repo/releases/:id", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: null, status: 204 });
+            await service.delete(1);
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/releases/1",
+                { method: "DELETE" },
+            );
+        });
+    });
+});

--- a/tests/unit/modules/releases/release.mapper.test.ts
+++ b/tests/unit/modules/releases/release.mapper.test.ts
@@ -1,0 +1,124 @@
+import {
+    mapRelease,
+    mapReleases,
+    mapReleaseAsset,
+    mapCreateReleaseParams,
+    mapUpdateReleaseParams,
+} from "../../../../src/modules/releases/release.mapper";
+import {
+    ReleaseDTO,
+    ReleaseAssetDTO,
+} from "../../../../src/modules/releases/release.dto";
+import { UserDTO } from "../../../../src/modules/users/user.dto";
+
+const mockUserDto: UserDTO = {
+    login: "testuser",
+    id: 1,
+    node_id: "U_1",
+    avatar_url: "",
+    html_url: "",
+    url: "",
+    type: "User",
+    site_admin: false,
+    name: null,
+    company: null,
+    blog: null,
+    location: null,
+    email: null,
+    bio: null,
+    twitter_username: null,
+    public_repos: 0,
+    public_gists: 0,
+    followers: 0,
+    following: 0,
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2020-01-01T00:00:00Z",
+};
+
+const mockAssetDto: ReleaseAssetDTO = {
+    id: 1,
+    node_id: "RA_1",
+    name: "release.zip",
+    label: null,
+    content_type: "application/zip",
+    size: 1024,
+    download_count: 5,
+    url: "https://api.github.com/repos/owner/repo/releases/assets/1",
+    browser_download_url:
+        "https://github.com/owner/repo/releases/download/v1.0.0/release.zip",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+};
+
+const mockReleaseDto: ReleaseDTO = {
+    id: 1,
+    node_id: "R_1",
+    tag_name: "v1.0.0",
+    target_commitish: "main",
+    name: "v1.0.0",
+    body: "Initial release",
+    draft: false,
+    prerelease: false,
+    author: mockUserDto,
+    assets: [mockAssetDto],
+    html_url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+    url: "https://api.github.com/repos/owner/repo/releases/1",
+    tarball_url: "https://api.github.com/repos/owner/repo/tarball/v1.0.0",
+    zipball_url: "https://api.github.com/repos/owner/repo/zipball/v1.0.0",
+    created_at: "2024-01-01T00:00:00Z",
+    published_at: "2024-01-02T00:00:00Z",
+};
+
+describe("release.mapper", () => {
+    describe("mapReleaseAsset", () => {
+        it("maps browser_download_url to downloadUrl", () => {
+            const result = mapReleaseAsset(mockAssetDto);
+            expect(result.downloadUrl).toBe(mockAssetDto.browser_download_url);
+            expect(result.downloadCount).toBe(5);
+        });
+    });
+
+    describe("mapRelease", () => {
+        it("maps snake_case fields to camelCase", () => {
+            const result = mapRelease(mockReleaseDto);
+            expect(result.tagName).toBe("v1.0.0");
+            expect(result.isDraft).toBe(false);
+            expect(result.isPrerelease).toBe(false);
+            expect(result.url).toBe(mockReleaseDto.html_url);
+            expect(result.apiUrl).toBe(mockReleaseDto.url);
+            expect(result.assets).toHaveLength(1);
+            expect(result.author.username).toBe("testuser");
+        });
+    });
+
+    describe("mapReleases", () => {
+        it("maps an array of releases", () => {
+            const result = mapReleases([mockReleaseDto]);
+            expect(result).toHaveLength(1);
+        });
+    });
+
+    describe("mapCreateReleaseParams", () => {
+        it("maps tagName and targetCommitish to snake_case", () => {
+            const result = mapCreateReleaseParams({
+                tagName: "v1.0.0",
+                targetCommitish: "main",
+                name: "v1.0.0",
+            });
+            expect(result.tag_name).toBe("v1.0.0");
+            expect(result.target_commitish).toBe("main");
+        });
+    });
+
+    describe("mapUpdateReleaseParams", () => {
+        it("maps camelCase params to snake_case payload", () => {
+            const result = mapUpdateReleaseParams({
+                releaseId: 1,
+                tagName: "v1.0.1",
+                prerelease: true,
+            });
+            expect(result.tag_name).toBe("v1.0.1");
+            expect(result.prerelease).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
New modules/releases/ following the four-file pattern, wired into GithubClient as github.releases. Methods: list(), get(), getLatest(), getByTag(), create(), update(), delete(). 12 new unit tests, 63 total passing, build clean.

Closes: #48