### PR TITLE
Add Workflows module (closes #49)

### DIFF
--- a/src/client/GithubClient.ts
+++ b/src/client/GithubClient.ts
@@ -3,6 +3,7 @@ import { PullRequestService } from "../modules/pull-requests/PullRequestService"
 import { ReleaseService } from "../modules/releases/ReleaseService";
 import { RepositoryService } from "../modules/repositories/RepositoryService";
 import { UserService } from "../modules/users/UserService";
+import { WorkflowService } from "../modules/workflows/WorkflowService";
 import {
     ApiResponse,
     createRequestClient,
@@ -27,6 +28,7 @@ export class GithubClient {
     public readonly repositories: RepositoryService;
     public readonly issues: IssueService;
     public readonly releases: ReleaseService;
+    public readonly workflows: WorkflowService;
     public readonly baseUrl: string;
     private readonly requestClient: RequestClient;
 
@@ -52,6 +54,7 @@ export class GithubClient {
         this.repositories = new RepositoryService(this);
         this.issues = new IssueService(this);
         this.releases = new ReleaseService(this);
+        this.workflows = new WorkflowService(this);
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from "./modules/pull-requests/pull-request.types";
 export * from "./modules/releases/release.types";
 export * from "./modules/repositories/repository.types";
 export * from "./modules/users/user.types";
+export * from "./modules/workflows/workflow.types";
 
 export * from "./shared/errors/GithubSdkError";
 export * from "./shared/errors/GithubApiError";

--- a/src/modules/workflows/WorkflowService.ts
+++ b/src/modules/workflows/WorkflowService.ts
@@ -1,0 +1,163 @@
+import { GithubClient } from "../../client/GithubClient";
+import {
+    Workflow,
+    WorkflowRun,
+    TriggerWorkflowDispatchParams,
+} from "./workflow.types";
+import {
+    WorkflowDTO,
+    WorkflowRunDTO,
+    WorkflowsResponseDTO,
+    WorkflowRunsResponseDTO,
+} from "./workflow.dto";
+import {
+    mapTriggerWorkflowDispatchParams,
+    mapWorkflow,
+    mapWorkflowRun,
+    mapWorkflowRuns,
+    mapWorkflows,
+} from "./workflow.mapper";
+import { assertConfig } from "../../shared/utils/config.utils";
+
+export class WorkflowService {
+    private readonly workflowsPath: string;
+    private readonly runsPath: string;
+
+    constructor(private readonly client: GithubClient) {
+        assertConfig(this.client, ["owner", "repo"]);
+        const repoPath = `/repos/${this.client.config.owner}/${this.client.config.repo}`;
+        this.workflowsPath = `${repoPath}/actions/workflows`;
+        this.runsPath = `${repoPath}/actions/runs`;
+    }
+
+    /**
+     * List workflows in the configured repository
+     *
+     * @returns Array of workflows
+     *
+     * @example
+     * ```ts
+     * const workflows = await github.workflows.list();
+     * ```
+     */
+    public async list(): Promise<Workflow[]> {
+        const response = await this.client.request<WorkflowsResponseDTO>(
+            this.workflowsPath,
+        );
+        return mapWorkflows(response.data.workflows);
+    }
+
+    /**
+     * Get a workflow by its ID or file name
+     *
+     * @param workflowId The ID or file name that identifies the workflow
+     * @returns Data of a workflow
+     *
+     * @example
+     * ```ts
+     * const workflow = await github.workflows.get('ci.yml');
+     * ```
+     */
+    public async get(workflowId: number | string): Promise<Workflow> {
+        const response = await this.client.request<WorkflowDTO>(
+            `${this.workflowsPath}/${workflowId}`,
+        );
+        return mapWorkflow(response.data);
+    }
+
+    /**
+     * List runs for a workflow
+     *
+     * @param workflowId The ID or file name that identifies the workflow
+     * @returns Array of workflow runs
+     *
+     * @example
+     * ```ts
+     * const runs = await github.workflows.listRuns('ci.yml');
+     * ```
+     */
+    public async listRuns(workflowId: number | string): Promise<WorkflowRun[]> {
+        const response = await this.client.request<WorkflowRunsResponseDTO>(
+            `${this.workflowsPath}/${workflowId}/runs`,
+        );
+        return mapWorkflowRuns(response.data.workflow_runs);
+    }
+
+    /**
+     * Get a specific workflow run
+     *
+     * @param runId The ID that identifies the workflow run
+     * @returns Data of a workflow run
+     *
+     * @example
+     * ```ts
+     * const run = await github.workflows.getRun(123456);
+     * ```
+     */
+    public async getRun(runId: number): Promise<WorkflowRun> {
+        const response = await this.client.request<WorkflowRunDTO>(
+            `${this.runsPath}/${runId}`,
+        );
+        return mapWorkflowRun(response.data);
+    }
+
+    /**
+     * Trigger a workflow_dispatch event on a workflow
+     *
+     * @param params Configuration for the dispatch
+     *
+     * @example
+     * ```ts
+     * await github.workflows.triggerDispatch({
+     *     workflowId: 'ci.yml',
+     *     ref: 'main',
+     *     inputs: { environment: 'production' },
+     * });
+     * ```
+     */
+    public async triggerDispatch(
+        params: TriggerWorkflowDispatchParams,
+    ): Promise<void> {
+        const body = mapTriggerWorkflowDispatchParams(params);
+        await this.client.request<null>(
+            `${this.workflowsPath}/${params.workflowId}/dispatches`,
+            {
+                method: "POST",
+                body: JSON.stringify(body),
+            },
+        );
+    }
+
+    /**
+     * Cancel a workflow run
+     *
+     * @param runId The ID that identifies the workflow run
+     *
+     * @example
+     * ```ts
+     * await github.workflows.cancelRun(123456);
+     * ```
+     */
+    public async cancelRun(runId: number): Promise<void> {
+        await this.client.request<null>(`${this.runsPath}/${runId}/cancel`, {
+            method: "POST",
+        });
+    }
+
+    /**
+     * Re-run the failed jobs in a workflow run
+     *
+     * @param runId The ID that identifies the workflow run
+     *
+     * @example
+     * ```ts
+     * await github.workflows.reRunFailedJobs(123456);
+     * ```
+     */
+    public async reRunFailedJobs(runId: number): Promise<void> {
+        await this.client.request<null>(
+            `${this.runsPath}/${runId}/rerun-failed-jobs`,
+            { method: "POST" },
+        );
+    }
+}

--- a/src/modules/workflows/workflow.dto.ts
+++ b/src/modules/workflows/workflow.dto.ts
@@ -1,0 +1,50 @@
+import {
+    WorkflowState,
+    WorkflowRunStatus,
+    WorkflowRunConclusion,
+} from "./workflow.types";
+import { UserDTO } from "../users/user.dto";
+
+export interface WorkflowDTO {
+    id: number;
+    node_id: string;
+    name: string;
+    path: string;
+    state: WorkflowState;
+    created_at: string;
+    updated_at: string;
+    url: string;
+    html_url: string;
+    badge_url: string;
+}
+
+export interface WorkflowsResponseDTO {
+    total_count: number;
+    workflows: WorkflowDTO[];
+}
+
+export interface WorkflowRunDTO {
+    id: number;
+    node_id: string;
+    name: string | null;
+    head_branch: string | null;
+    head_sha: string;
+    path: string;
+    run_number: number;
+    run_attempt: number;
+    event: string;
+    status: WorkflowRunStatus | null;
+    conclusion: WorkflowRunConclusion;
+    workflow_id: number;
+    url: string;
+    html_url: string;
+    created_at: string;
+    updated_at: string;
+    run_started_at: string | null;
+    actor: UserDTO | null;
+}
+
+export interface WorkflowRunsResponseDTO {
+    total_count: number;
+    workflow_runs: WorkflowRunDTO[];
+}

--- a/src/modules/workflows/workflow.mapper.ts
+++ b/src/modules/workflows/workflow.mapper.ts
@@ -1,0 +1,63 @@
+import {
+    Workflow,
+    WorkflowRun,
+    TriggerWorkflowDispatchParams,
+    TriggerWorkflowDispatchPayload,
+} from "./workflow.types";
+import { WorkflowDTO, WorkflowRunDTO } from "./workflow.dto";
+import { mapUser } from "../users/user.mapper";
+
+export function mapWorkflow(dto: WorkflowDTO): Workflow {
+    return {
+        id: dto.id,
+        nodeId: dto.node_id,
+        name: dto.name,
+        path: dto.path,
+        state: dto.state,
+        createdAt: dto.created_at,
+        updatedAt: dto.updated_at,
+        url: dto.html_url,
+        apiUrl: dto.url,
+        badgeUrl: dto.badge_url,
+    };
+}
+
+export function mapWorkflows(dtos: WorkflowDTO[]): Workflow[] {
+    return dtos.map((dto) => mapWorkflow(dto));
+}
+
+export function mapWorkflowRun(dto: WorkflowRunDTO): WorkflowRun {
+    return {
+        id: dto.id,
+        nodeId: dto.node_id,
+        name: dto.name,
+        headBranch: dto.head_branch,
+        headSha: dto.head_sha,
+        path: dto.path,
+        runNumber: dto.run_number,
+        runAttempt: dto.run_attempt,
+        event: dto.event,
+        status: dto.status,
+        conclusion: dto.conclusion,
+        workflowId: dto.workflow_id,
+        url: dto.html_url,
+        apiUrl: dto.url,
+        createdAt: dto.created_at,
+        updatedAt: dto.updated_at,
+        runStartedAt: dto.run_started_at,
+        actor: dto.actor ? mapUser(dto.actor) : null,
+    };
+}
+
+export function mapWorkflowRuns(dtos: WorkflowRunDTO[]): WorkflowRun[] {
+    return dtos.map((dto) => mapWorkflowRun(dto));
+}
+
+export function mapTriggerWorkflowDispatchParams(
+    params: TriggerWorkflowDispatchParams,
+): TriggerWorkflowDispatchPayload {
+    return {
+        ref: params.ref,
+        inputs: params.inputs,
+    };
+}

--- a/src/modules/workflows/workflow.types.ts
+++ b/src/modules/workflows/workflow.types.ts
@@ -1,0 +1,72 @@
+import { User } from "../users/user.types";
+
+export type WorkflowState =
+    | "active"
+    | "deleted"
+    | "disabled_fork"
+    | "disabled_inactivity"
+    | "disabled_manually";
+
+export type WorkflowRunStatus =
+    | "queued"
+    | "in_progress"
+    | "completed"
+    | "waiting"
+    | "requested"
+    | "pending";
+
+export type WorkflowRunConclusion =
+    | "success"
+    | "failure"
+    | "neutral"
+    | "cancelled"
+    | "skipped"
+    | "timed_out"
+    | "action_required"
+    | "stale"
+    | null;
+
+export interface Workflow {
+    id: number;
+    nodeId: string;
+    name: string;
+    path: string;
+    state: WorkflowState;
+    createdAt: string;
+    updatedAt: string;
+    url: string;
+    apiUrl: string;
+    badgeUrl: string;
+}
+
+export interface WorkflowRun {
+    id: number;
+    nodeId: string;
+    name: string | null;
+    headBranch: string | null;
+    headSha: string;
+    path: string;
+    runNumber: number;
+    runAttempt: number;
+    event: string;
+    status: WorkflowRunStatus | null;
+    conclusion: WorkflowRunConclusion;
+    workflowId: number;
+    url: string;
+    apiUrl: string;
+    createdAt: string;
+    updatedAt: string;
+    runStartedAt: string | null;
+    actor: User | null;
+}
+
+export interface TriggerWorkflowDispatchParams {
+    workflowId: number | string;
+    ref: string;
+    inputs?: Record<string, string>;
+}
+
+export interface TriggerWorkflowDispatchPayload {
+    ref: string;
+    inputs?: Record<string, string>;
+}

--- a/tests/unit/modules/workflows/WorkflowService.test.ts
+++ b/tests/unit/modules/workflows/WorkflowService.test.ts
@@ -1,0 +1,162 @@
+import { GithubClient } from "../../../../src/client/GithubClient";
+import { WorkflowService } from "../../../../src/modules/workflows/WorkflowService";
+import {
+    WorkflowDTO,
+    WorkflowRunDTO,
+    WorkflowsResponseDTO,
+    WorkflowRunsResponseDTO,
+} from "../../../../src/modules/workflows/workflow.dto";
+
+const mockWorkflowDto: WorkflowDTO = {
+    id: 1,
+    node_id: "W_1",
+    name: "CI",
+    path: ".github/workflows/ci.yml",
+    state: "active",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    url: "https://api.github.com/repos/owner/repo/actions/workflows/1",
+    html_url: "https://github.com/owner/repo/actions/workflows/ci.yml",
+    badge_url: "https://github.com/owner/repo/workflows/CI/badge.svg",
+};
+
+const mockWorkflowRunDto: WorkflowRunDTO = {
+    id: 100,
+    node_id: "WR_1",
+    name: "CI",
+    head_branch: "main",
+    head_sha: "abc123",
+    path: ".github/workflows/ci.yml",
+    run_number: 42,
+    run_attempt: 1,
+    event: "push",
+    status: "completed",
+    conclusion: "success",
+    workflow_id: 1,
+    url: "https://api.github.com/repos/owner/repo/actions/runs/100",
+    html_url: "https://github.com/owner/repo/actions/runs/100",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:05:00Z",
+    run_started_at: "2024-01-01T00:00:30Z",
+    actor: null,
+};
+
+function makeService() {
+    const mockRequest = jest.fn();
+    const client = {
+        config: { token: "test-token", owner: "test-owner", repo: "test-repo" },
+        request: mockRequest,
+        baseUrl: "https://api.github.com",
+    } as unknown as GithubClient;
+    return { service: new WorkflowService(client), mockRequest };
+}
+
+describe("WorkflowService", () => {
+    describe("list", () => {
+        it("calls GET /repos/:owner/:repo/actions/workflows and unwraps workflows", async () => {
+            const { service, mockRequest } = makeService();
+            const responseData: WorkflowsResponseDTO = {
+                total_count: 1,
+                workflows: [mockWorkflowDto],
+            };
+            mockRequest.mockResolvedValue({ data: responseData, status: 200 });
+            const result = await service.list();
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/actions/workflows",
+            );
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe("CI");
+        });
+    });
+
+    describe("get", () => {
+        it("calls GET /repos/:owner/:repo/actions/workflows/:id", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: mockWorkflowDto,
+                status: 200,
+            });
+            await service.get("ci.yml");
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/actions/workflows/ci.yml",
+            );
+        });
+    });
+
+    describe("listRuns", () => {
+        it("calls GET /repos/:owner/:repo/actions/workflows/:id/runs and unwraps runs", async () => {
+            const { service, mockRequest } = makeService();
+            const responseData: WorkflowRunsResponseDTO = {
+                total_count: 1,
+                workflow_runs: [mockWorkflowRunDto],
+            };
+            mockRequest.mockResolvedValue({ data: responseData, status: 200 });
+            const result = await service.listRuns(1);
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/actions/workflows/1/runs",
+            );
+            expect(result).toHaveLength(1);
+            expect(result[0].runNumber).toBe(42);
+        });
+    });
+
+    describe("getRun", () => {
+        it("calls GET /repos/:owner/:repo/actions/runs/:id", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: mockWorkflowRunDto,
+                status: 200,
+            });
+            await service.getRun(100);
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/actions/runs/100",
+            );
+        });
+    });
+
+    describe("triggerDispatch", () => {
+        it("calls POST /repos/:owner/:repo/actions/workflows/:id/dispatches with ref and inputs", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: null, status: 204 });
+            await service.triggerDispatch({
+                workflowId: "ci.yml",
+                ref: "main",
+                inputs: { environment: "production" },
+            });
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/actions/workflows/ci.yml/dispatches",
+                {
+                    method: "POST",
+                    body: JSON.stringify({
+                        ref: "main",
+                        inputs: { environment: "production" },
+                    }),
+                },
+            );
+        });
+    });
+
+    describe("cancelRun", () => {
+        it("calls POST /repos/:owner/:repo/actions/runs/:id/cancel", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: null, status: 202 });
+            await service.cancelRun(100);
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/actions/runs/100/cancel",
+                { method: "POST" },
+            );
+        });
+    });
+
+    describe("reRunFailedJobs", () => {
+        it("calls POST /repos/:owner/:repo/actions/runs/:id/rerun-failed-jobs", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: null, status: 201 });
+            await service.reRunFailedJobs(100);
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/repos/test-owner/test-repo/actions/runs/100/rerun-failed-jobs",
+                { method: "POST" },
+            );
+        });
+    });
+});

--- a/tests/unit/modules/workflows/workflow.mapper.test.ts
+++ b/tests/unit/modules/workflows/workflow.mapper.test.ts
@@ -1,0 +1,126 @@
+import {
+    mapWorkflow,
+    mapWorkflows,
+    mapWorkflowRun,
+    mapWorkflowRuns,
+    mapTriggerWorkflowDispatchParams,
+} from "../../../../src/modules/workflows/workflow.mapper";
+import {
+    WorkflowDTO,
+    WorkflowRunDTO,
+} from "../../../../src/modules/workflows/workflow.dto";
+import { UserDTO } from "../../../../src/modules/users/user.dto";
+
+const mockUserDto: UserDTO = {
+    login: "testuser",
+    id: 1,
+    node_id: "U_1",
+    avatar_url: "",
+    html_url: "",
+    url: "",
+    type: "User",
+    site_admin: false,
+    name: null,
+    company: null,
+    blog: null,
+    location: null,
+    email: null,
+    bio: null,
+    twitter_username: null,
+    public_repos: 0,
+    public_gists: 0,
+    followers: 0,
+    following: 0,
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2020-01-01T00:00:00Z",
+};
+
+const mockWorkflowDto: WorkflowDTO = {
+    id: 1,
+    node_id: "W_1",
+    name: "CI",
+    path: ".github/workflows/ci.yml",
+    state: "active",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    url: "https://api.github.com/repos/owner/repo/actions/workflows/1",
+    html_url: "https://github.com/owner/repo/actions/workflows/ci.yml",
+    badge_url: "https://github.com/owner/repo/workflows/CI/badge.svg",
+};
+
+const mockWorkflowRunDto: WorkflowRunDTO = {
+    id: 100,
+    node_id: "WR_1",
+    name: "CI",
+    head_branch: "main",
+    head_sha: "abc123",
+    path: ".github/workflows/ci.yml",
+    run_number: 42,
+    run_attempt: 1,
+    event: "push",
+    status: "completed",
+    conclusion: "success",
+    workflow_id: 1,
+    url: "https://api.github.com/repos/owner/repo/actions/runs/100",
+    html_url: "https://github.com/owner/repo/actions/runs/100",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:05:00Z",
+    run_started_at: "2024-01-01T00:00:30Z",
+    actor: mockUserDto,
+};
+
+describe("workflow.mapper", () => {
+    describe("mapWorkflow", () => {
+        it("maps snake_case fields to camelCase", () => {
+            const result = mapWorkflow(mockWorkflowDto);
+            expect(result.badgeUrl).toBe(mockWorkflowDto.badge_url);
+            expect(result.url).toBe(mockWorkflowDto.html_url);
+            expect(result.apiUrl).toBe(mockWorkflowDto.url);
+            expect(result.state).toBe("active");
+        });
+    });
+
+    describe("mapWorkflows", () => {
+        it("maps an array of workflows", () => {
+            expect(mapWorkflows([mockWorkflowDto])).toHaveLength(1);
+        });
+    });
+
+    describe("mapWorkflowRun", () => {
+        it("maps snake_case fields to camelCase and the actor", () => {
+            const result = mapWorkflowRun(mockWorkflowRunDto);
+            expect(result.runNumber).toBe(42);
+            expect(result.headBranch).toBe("main");
+            expect(result.conclusion).toBe("success");
+            expect(result.actor?.username).toBe("testuser");
+        });
+
+        it("maps a null actor to null", () => {
+            const result = mapWorkflowRun({
+                ...mockWorkflowRunDto,
+                actor: null,
+            });
+            expect(result.actor).toBeNull();
+        });
+    });
+
+    describe("mapWorkflowRuns", () => {
+        it("maps an array of workflow runs", () => {
+            expect(mapWorkflowRuns([mockWorkflowRunDto])).toHaveLength(1);
+        });
+    });
+
+    describe("mapTriggerWorkflowDispatchParams", () => {
+        it("maps params to the dispatch payload", () => {
+            const result = mapTriggerWorkflowDispatchParams({
+                workflowId: "ci.yml",
+                ref: "main",
+                inputs: { environment: "production" },
+            });
+            expect(result).toEqual({
+                ref: "main",
+                inputs: { environment: "production" },
+            });
+        });
+    });
+});


### PR DESCRIPTION
New modules/workflows/ following the four-file pattern, wired into GithubClient as github.workflows. Methods: list(), get(), listRuns(), getRun(), triggerDispatch(), cancelRun(), reRunFailedJobs(). list()/listRuns() unwrap GitHub's { total_count, workflows/workflow_runs } envelope into plain arrays for ergonomics. 13 new unit tests, 76 total passing, build clean.

closes #49