### PR TITLE
Add GitHub App auth via a shared GitHubAuth interface

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ module.exports = {
     collectCoverageFrom: ["src/**/*.ts"],
     passWithNoTests: true,
     transform: {
-        "^.+\\.tsx?$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.jest.json" }],
+        "^.+\\.tsx?$": [
+            "ts-jest",
+            { tsconfig: "<rootDir>/tsconfig.jest.json" },
+        ],
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "@lujax/github-sdk",
             "version": "1.0.0",
             "license": "MIT",
+            "dependencies": {
+                "jose": "^5.10.0"
+            },
             "devDependencies": {
                 "@types/jest": "^29.5.14",
                 "@types/node": "^25.5.2",
@@ -2725,6 +2728,15 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/jose": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+            "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
             }
         },
         "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lujax/github-sdk",
     "version": "1.0.0",
-    "description": "TypeScript-first GitHub REST API SDK - ergonomic, typed, zero dependencies",
+    "description": "TypeScript-first GitHub REST API SDK - ergonomic, typed, near-zero dependencies",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "files": [
@@ -30,5 +30,8 @@
         "prettier": "^3.8.3",
         "ts-jest": "^29.4.11",
         "typescript": "^6.0.2"
+    },
+    "dependencies": {
+        "jose": "^5.10.0"
     }
 }

--- a/src/auth/GitHubAppAuth.ts
+++ b/src/auth/GitHubAppAuth.ts
@@ -1,0 +1,120 @@
+import { importPKCS8, SignJWT } from "jose";
+import { GithubApiError } from "../shared/errors/GithubApiError";
+import { GitHubAuth } from "./GitHubAuth";
+
+export interface GitHubAppAuthConfig {
+    /** The GitHub App's ID (from the App's settings page). */
+    appId: string;
+    /** The App's PEM-encoded PKCS8 private key. */
+    privateKey: string;
+    /** The installation to authenticate as. */
+    installationId: string;
+    /** Override for GitHub Enterprise Server. Defaults to `https://api.github.com`. */
+    baseUrl?: string;
+}
+
+interface InstallationTokenResponse {
+    token: string;
+    expires_at: string;
+}
+
+interface GithubApiErrorResponse {
+    message: string;
+    documentation_url?: string;
+}
+
+const JWT_TTL_SECONDS = 600;
+const JWT_CLOCK_DRIFT_SECONDS = 60;
+const REFRESH_MARGIN_MS = 60_000;
+
+/**
+ * GitHub App authentication: signs a short-lived JWT from the App's private
+ * key, exchanges it for an installation access token, and transparently
+ * re-exchanges once the cached token is close to expiring. Refresh happens
+ * lazily inside {@link getToken} — there is no background timer.
+ *
+ * @example
+ * ```ts
+ * const auth = new GitHubAppAuth({
+ *     appId: process.env.GITHUB_APP_ID,
+ *     privateKey: process.env.GITHUB_APP_PRIVATE_KEY,
+ *     installationId: process.env.GITHUB_APP_INSTALLATION_ID,
+ * });
+ * const github = new GithubClient({ auth, owner: 'lujax-dev', repo: 'github-sdk' });
+ * ```
+ */
+export class GitHubAppAuth implements GitHubAuth {
+    private cachedToken: string | null = null;
+    private cachedTokenExpiresAtMs: number | null = null;
+
+    constructor(private readonly config: GitHubAppAuthConfig) {}
+
+    async getToken(): Promise<string> {
+        if (this.cachedToken && !this.isNearExpiry()) {
+            return this.cachedToken;
+        }
+
+        const jwt = await this.signAppJwt();
+        const { token, expiresAtMs } =
+            await this.exchangeForInstallationToken(jwt);
+
+        this.cachedToken = token;
+        this.cachedTokenExpiresAtMs = expiresAtMs;
+        return token;
+    }
+
+    private isNearExpiry(): boolean {
+        if (this.cachedTokenExpiresAtMs === null) {
+            return true;
+        }
+        return Date.now() >= this.cachedTokenExpiresAtMs - REFRESH_MARGIN_MS;
+    }
+
+    private async signAppJwt(): Promise<string> {
+        const key = await importPKCS8(this.config.privateKey, "RS256");
+        const nowSeconds = Math.floor(Date.now() / 1000);
+
+        return new SignJWT({})
+            .setProtectedHeader({ alg: "RS256" })
+            .setIssuedAt(nowSeconds - JWT_CLOCK_DRIFT_SECONDS)
+            .setExpirationTime(nowSeconds + JWT_TTL_SECONDS)
+            .setIssuer(this.config.appId)
+            .sign(key);
+    }
+
+    private async exchangeForInstallationToken(
+        jwt: string,
+    ): Promise<{ token: string; expiresAtMs: number }> {
+        const baseUrl = this.config.baseUrl ?? "https://api.github.com";
+        const response = await fetch(
+            `${baseUrl}/app/installations/${this.config.installationId}/access_tokens`,
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${jwt}`,
+                    Accept: "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            },
+        );
+
+        const text = await response.text();
+        const data = text ? JSON.parse(text) : null;
+
+        if (!response.ok) {
+            const error = data as GithubApiErrorResponse;
+            throw new GithubApiError(
+                response.status,
+                error?.message ??
+                    "Failed to exchange JWT for an installation access token",
+                error?.documentation_url,
+            );
+        }
+
+        const body = data as InstallationTokenResponse;
+        return {
+            token: body.token,
+            expiresAtMs: new Date(body.expires_at).getTime(),
+        };
+    }
+}

--- a/src/auth/GitHubAuth.ts
+++ b/src/auth/GitHubAuth.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared interface for GitHub authentication strategies. Both {@link PatAuth}
+ * and {@link GitHubAppAuth} implement this so `GithubClient` can accept
+ * either without changing how requests are made.
+ */
+export interface GitHubAuth {
+    /**
+     * Resolve the current bearer token to send with a request. Implementations
+     * that hold a rotating credential (e.g. a GitHub App installation token)
+     * should refresh internally here rather than requiring the caller to.
+     */
+    getToken(): Promise<string>;
+}

--- a/src/auth/PatAuth.ts
+++ b/src/auth/PatAuth.ts
@@ -1,0 +1,17 @@
+import { GitHubAuth } from "./GitHubAuth";
+
+/**
+ * Wraps a static Personal Access Token as a {@link GitHubAuth} strategy.
+ *
+ * @example
+ * ```ts
+ * const github = new GithubClient({ auth: new PatAuth(process.env.GITHUB_TOKEN) });
+ * ```
+ */
+export class PatAuth implements GitHubAuth {
+    constructor(private readonly token: string) {}
+
+    async getToken(): Promise<string> {
+        return this.token;
+    }
+}

--- a/src/client/GithubClient.ts
+++ b/src/client/GithubClient.ts
@@ -1,9 +1,11 @@
+import { GitHubAuth } from "../auth/GitHubAuth";
 import { IssueService } from "../modules/issues/IssueService";
 import { PullRequestService } from "../modules/pull-requests/PullRequestService";
 import { ReleaseService } from "../modules/releases/ReleaseService";
 import { RepositoryService } from "../modules/repositories/RepositoryService";
 import { UserService } from "../modules/users/UserService";
 import { WorkflowService } from "../modules/workflows/WorkflowService";
+import { InvalidTokenError } from "../shared/errors/InvalidTokenError";
 import {
     ApiResponse,
     createRequestClient,
@@ -11,7 +13,10 @@ import {
 } from "../shared/utils/request.utils";
 
 export interface GithubClientConfig {
-    token: string;
+    /** A Personal Access Token. Ignored if `auth` is also set. */
+    token?: string;
+    /** A {@link GitHubAuth} strategy, e.g. `new GitHubAppAuth(...)`. Takes precedence over `token`. */
+    auth?: GitHubAuth;
     owner?: string;
     repo?: string;
     org?: string;
@@ -45,10 +50,29 @@ export class GithubClient {
      *     repo: 'github-sdk'
      * });
      * ```
+     *
+     * @example Authenticating as a GitHub App instead of a PAT
+     * ```ts
+     * import { GithubClient, GitHubAppAuth } from "@lujax/github-sdk";
+     *
+     * const github = new GithubClient({
+     *     auth: new GitHubAppAuth({
+     *         appId: process.env.GITHUB_APP_ID,
+     *         privateKey: process.env.GITHUB_APP_PRIVATE_KEY,
+     *         installationId: process.env.GITHUB_APP_INSTALLATION_ID,
+     *     }),
+     *     owner: 'lujax-dev',
+     *     repo: 'github-sdk'
+     * });
+     * ```
      */
     constructor(public readonly config: GithubClientConfig) {
         this.baseUrl = "https://api.github.com";
-        this.requestClient = createRequestClient(this.baseUrl, config.token);
+        const auth = config.auth ?? config.token;
+        if (!auth) {
+            throw new InvalidTokenError();
+        }
+        this.requestClient = createRequestClient(this.baseUrl, auth);
         this.pullRequests = new PullRequestService(this);
         this.users = new UserService(this);
         this.repositories = new RepositoryService(this);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
 export { GithubClient } from "./client/GithubClient";
+export type { GithubClientConfig } from "./client/GithubClient";
+
+export * from "./auth/GitHubAuth";
+export * from "./auth/PatAuth";
+export * from "./auth/GitHubAppAuth";
 
 export * from "./modules/commits/commit.types";
 export * from "./modules/issues/issue.types";

--- a/src/shared/utils/request.utils.ts
+++ b/src/shared/utils/request.utils.ts
@@ -1,3 +1,4 @@
+import { GitHubAuth } from "../../auth/GitHubAuth";
 import { GithubApiError } from "../errors/GithubApiError";
 
 interface GithubApiErrorResponse {
@@ -32,14 +33,21 @@ interface CacheEntry {
 }
 
 /**
- * Builds a `request<T>` function bound to a base URL and token. Rate-limit
- * state and the ETag cache are held in closure so each GithubClient instance
- * (and each token) gets its own isolated state.
+ * Builds a `request<T>` function bound to a base URL and an auth strategy.
+ * Rate-limit state and the ETag cache are held in closure so each
+ * GithubClient instance gets its own isolated state.
+ *
+ * `auth` accepts a plain token string (PAT, back-compat) or a
+ * {@link GitHubAuth} strategy — the token is resolved fresh on every
+ * request, so a rotating strategy like `GitHubAppAuth` stays valid without
+ * the caller needing to do anything.
  */
 export function createRequestClient(
     baseUrl: string,
-    token: string,
+    auth: string | GitHubAuth,
 ): RequestClient {
+    const resolveToken =
+        typeof auth === "string" ? async () => auth : () => auth.getToken();
     let rateLimitRemaining: number | null = null;
     let rateLimitResetAt: number | null = null;
     const etagCache = new Map<string, CacheEntry>();
@@ -75,6 +83,7 @@ export function createRequestClient(
         const url = `${baseUrl}${path}`;
         const isGet = (options.method ?? "GET").toUpperCase() === "GET";
         const cached = isGet ? etagCache.get(url) : undefined;
+        const token = await resolveToken();
 
         const headers: Record<string, string> = {
             "X-GitHub-Api-Version": "2022-11-28",

--- a/tests/unit/auth/GitHubAppAuth.test.ts
+++ b/tests/unit/auth/GitHubAppAuth.test.ts
@@ -1,0 +1,129 @@
+import { generateKeyPairSync } from "crypto";
+import { GitHubAppAuth } from "../../../src/auth/GitHubAppAuth";
+
+function generateTestPrivateKeyPem(): string {
+    const { privateKey } = generateKeyPairSync("rsa", {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: "spki", format: "pem" },
+        privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    });
+    return privateKey as unknown as string;
+}
+
+function mockResponse(status: number, body: unknown): Response {
+    return {
+        status,
+        ok: status >= 200 && status < 300,
+        text: async () => (body === null ? "" : JSON.stringify(body)),
+    } as unknown as Response;
+}
+
+describe("GitHubAppAuth", () => {
+    const privateKey = generateTestPrivateKeyPem();
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("signs a JWT and exchanges it for an installation access token", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(
+            mockResponse(201, {
+                token: "installation-token-1",
+                expires_at: new Date(Date.now() + 3600_000).toISOString(),
+            }),
+        );
+        global.fetch = fetchMock;
+
+        const auth = new GitHubAppAuth({
+            appId: "12345",
+            privateKey,
+            installationId: "67890",
+        });
+
+        await expect(auth.getToken()).resolves.toBe("installation-token-1");
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://api.github.com/app/installations/67890/access_tokens",
+            expect.objectContaining({
+                method: "POST",
+                headers: expect.objectContaining({
+                    Accept: "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                }),
+            }),
+        );
+        const authHeader = (
+            fetchMock.mock.calls[0][1] as { headers: Record<string, string> }
+        ).headers.Authorization;
+        expect(authHeader).toMatch(/^Bearer ey/);
+    });
+
+    it("caches the installation token and does not re-exchange while it's still valid", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(
+            mockResponse(201, {
+                token: "installation-token-1",
+                expires_at: new Date(Date.now() + 3600_000).toISOString(),
+            }),
+        );
+        global.fetch = fetchMock;
+
+        const auth = new GitHubAppAuth({
+            appId: "12345",
+            privateKey,
+            installationId: "67890",
+        });
+
+        await auth.getToken();
+        await auth.getToken();
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-exchanges once the cached token is within the refresh margin of expiry", async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValueOnce(
+                mockResponse(201, {
+                    token: "installation-token-1",
+                    expires_at: new Date(Date.now() + 30_000).toISOString(),
+                }),
+            )
+            .mockResolvedValueOnce(
+                mockResponse(201, {
+                    token: "installation-token-2",
+                    expires_at: new Date(Date.now() + 3600_000).toISOString(),
+                }),
+            );
+        global.fetch = fetchMock;
+
+        const auth = new GitHubAppAuth({
+            appId: "12345",
+            privateKey,
+            installationId: "67890",
+        });
+
+        await expect(auth.getToken()).resolves.toBe("installation-token-1");
+        await expect(auth.getToken()).resolves.toBe("installation-token-2");
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws GithubApiError when the token exchange fails", async () => {
+        global.fetch = jest.fn().mockResolvedValue(
+            mockResponse(404, {
+                message: "Not Found",
+                documentation_url: "https://docs.github.com/errors",
+            }),
+        );
+
+        const auth = new GitHubAppAuth({
+            appId: "12345",
+            privateKey,
+            installationId: "does-not-exist",
+        });
+
+        await expect(auth.getToken()).rejects.toMatchObject({
+            status: 404,
+            documentationUrl: "https://docs.github.com/errors",
+        });
+    });
+});

--- a/tests/unit/auth/PatAuth.test.ts
+++ b/tests/unit/auth/PatAuth.test.ts
@@ -1,0 +1,16 @@
+import { PatAuth } from "../../../src/auth/PatAuth";
+
+describe("PatAuth", () => {
+    it("resolves the wrapped token", async () => {
+        const auth = new PatAuth("my-token");
+
+        await expect(auth.getToken()).resolves.toBe("my-token");
+    });
+
+    it("resolves the same token on repeated calls", async () => {
+        const auth = new PatAuth("my-token");
+
+        await expect(auth.getToken()).resolves.toBe("my-token");
+        await expect(auth.getToken()).resolves.toBe("my-token");
+    });
+});

--- a/tests/unit/client/GithubClient.test.ts
+++ b/tests/unit/client/GithubClient.test.ts
@@ -1,0 +1,62 @@
+import { GithubClient } from "../../../src/client/GithubClient";
+import { InvalidTokenError } from "../../../src/shared/errors/InvalidTokenError";
+import { GitHubAuth } from "../../../src/auth/GitHubAuth";
+
+function mockResponse(status: number, body: unknown): Response {
+    return {
+        status,
+        ok: status >= 200 && status < 300,
+        headers: new Headers(),
+        text: async () => (body === null ? "" : JSON.stringify(body)),
+    } as unknown as Response;
+}
+
+describe("GithubClient", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("throws InvalidTokenError when neither token nor auth is provided", () => {
+        expect(() => new GithubClient({})).toThrow(InvalidTokenError);
+    });
+
+    it("authenticates with a plain PAT string", async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValue(mockResponse(200, { login: "octocat" }));
+        global.fetch = fetchMock;
+
+        const github = new GithubClient({
+            token: "pat-token",
+            owner: "lujax-dev",
+            repo: "github-sdk",
+        });
+        await github.request("/user");
+
+        const headers = (
+            fetchMock.mock.calls[0][1] as { headers: Record<string, string> }
+        ).headers;
+        expect(headers.Authorization).toBe("Bearer pat-token");
+    });
+
+    it("authenticates with a custom GitHubAuth strategy, which takes precedence over token", async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValue(mockResponse(200, { login: "octocat" }));
+        global.fetch = fetchMock;
+
+        const auth: GitHubAuth = { getToken: async () => "auth-token" };
+        const github = new GithubClient({
+            token: "pat-token",
+            auth,
+            owner: "lujax-dev",
+            repo: "github-sdk",
+        });
+        await github.request("/user");
+
+        const headers = (
+            fetchMock.mock.calls[0][1] as { headers: Record<string, string> }
+        ).headers;
+        expect(headers.Authorization).toBe("Bearer auth-token");
+    });
+});

--- a/tests/unit/modules/users/UserService.test.ts
+++ b/tests/unit/modules/users/UserService.test.ts
@@ -68,7 +68,9 @@ describe("UserService", () => {
         it("returns mapped updated User", async () => {
             const { service, mockRequest } = makeService();
             mockRequest.mockResolvedValue({ data: mockUserDto, status: 200 });
-            const result = await service.updateAuthenticated({ name: "New Name" });
+            const result = await service.updateAuthenticated({
+                name: "New Name",
+            });
             expect(result.username).toBe("testuser");
         });
     });

--- a/tests/unit/shared/utils/request.utils.test.ts
+++ b/tests/unit/shared/utils/request.utils.test.ts
@@ -236,6 +236,41 @@ describe("createRequestClient", () => {
         });
     });
 
+    describe("GitHubAuth strategies", () => {
+        it("resolves the token from a GitHubAuth on every request, supporting rotation", async () => {
+            const fetchMock = jest
+                .fn()
+                .mockResolvedValue(mockResponse(200, { ok: true }));
+            global.fetch = fetchMock;
+
+            let calls = 0;
+            const auth = {
+                getToken: jest.fn(async () => {
+                    calls++;
+                    return `token-${calls}`;
+                }),
+            };
+
+            const client = createRequestClient("https://api.github.com", auth);
+            await client("/first");
+            await client("/second");
+
+            expect(auth.getToken).toHaveBeenCalledTimes(2);
+            const firstHeaders = (
+                fetchMock.mock.calls[0][1] as {
+                    headers: Record<string, string>;
+                }
+            ).headers;
+            const secondHeaders = (
+                fetchMock.mock.calls[1][1] as {
+                    headers: Record<string, string>;
+                }
+            ).headers;
+            expect(firstHeaders.Authorization).toBe("Bearer token-1");
+            expect(secondHeaders.Authorization).toBe("Bearer token-2");
+        });
+    });
+
     describe("ETag caching", () => {
         it("sends If-None-Match on a repeat GET and returns cached data on 304", async () => {
             const fetchMock = jest


### PR DESCRIPTION
## What's in this PR

- New `src/auth/` module: `GitHubAuth` (shared interface — `getToken(): Promise<string>`), `PatAuth` (wraps a static PAT), and `GitHubAppAuth` (JWT signing via `jose` + installation access token exchange).
- `GitHubAppAuth` refreshes lazily: it checks the cached token's expiry on each call and only re-signs/re-exchanges when within 60s of expiry, rather than running a background timer. No caller involvement needed to keep a long-lived process authenticated.
- `createRequestClient` now accepts either a plain token string (unchanged, backward compatible) or a `GitHubAuth`, resolving the token fresh on every request so rotation works transparently.
- `GithubClientConfig` gains an optional `auth` field (a `GitHubAuth`), which takes precedence over `token` if both are set. Throws `InvalidTokenError` if neither is provided.
- `GitHubAuth`, `PatAuth`, `GitHubAppAuth`, and `GithubClientConfig` are now exported from `index.ts`.

## Why

PAT auth already covers the SDK's core use case end-to-end, but GitHub App auth is needed for any production/multi-installation use case (and was tracked as part of v1 scope). Went with the full build over a simplified "bring your own installation token" alternative — the lazy-refresh design turned out to not add much complexity over a stub.

## Bug found and fixed along the way

`jose` v6 (the version that installs by default) dropped its CommonJS build entirely — it's `"type": "module"` with no `require` export condition. Since this package compiles to CommonJS, `require("jose")` would have thrown `ERR_REQUIRE_ESM` at runtime for any real consumer, even though `tsc` and Jest didn't catch it at build time. Pinned to `jose@^5.10.0`, which still ships a dual CJS/ESM build with the identical `SignJWT`/`importPKCS8` API.

## Testing

- 10 new unit tests (`PatAuth`, `GitHubAppAuth` — JWT signing + exchange + caching + refresh-on-near-expiry + error handling, `GithubClient` auth resolution, `createRequestClient` per-request token resolution)
- 86 tests total, all passing
- `npm run build` clean

Closes #46