### PR TITLE
Add OrganizationService (closes #66)

### DIFF
--- a/src/client/GithubClient.ts
+++ b/src/client/GithubClient.ts
@@ -1,5 +1,6 @@
 import { GitHubAuth } from "../auth/GitHubAuth";
 import { IssueService } from "../modules/issues/IssueService";
+import { OrganizationService } from "../modules/organizations/OrganizationService";
 import { PullRequestService } from "../modules/pull-requests/PullRequestService";
 import { ReleaseService } from "../modules/releases/ReleaseService";
 import { RepositoryService } from "../modules/repositories/RepositoryService";
@@ -34,6 +35,7 @@ export class GithubClient {
     public readonly issues: IssueService;
     public readonly releases: ReleaseService;
     public readonly workflows: WorkflowService;
+    public readonly organizations: OrganizationService;
     public readonly baseUrl: string;
     private readonly requestClient: RequestClient;
 
@@ -79,6 +81,7 @@ export class GithubClient {
         this.issues = new IssueService(this);
         this.releases = new ReleaseService(this);
         this.workflows = new WorkflowService(this);
+        this.organizations = new OrganizationService(this);
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from "./auth/GitHubAppAuth";
 
 export * from "./modules/commits/commit.types";
 export * from "./modules/issues/issue.types";
+export * from "./modules/organizations/organization.types";
 export * from "./modules/pull-requests/pull-request.types";
 export * from "./modules/releases/release.types";
 export * from "./modules/repositories/repository.types";

--- a/src/modules/organizations/OrganizationService.ts
+++ b/src/modules/organizations/OrganizationService.ts
@@ -1,0 +1,260 @@
+import { GithubClient } from "../../client/GithubClient";
+import { GithubApiError } from "../../shared/errors/GithubApiError";
+import { assertConfig } from "../../shared/utils/config.utils";
+import {
+    Organization,
+    SimpleOrganization,
+    UpdateOrganizationParams,
+    OrgMembership,
+    UpdateOrgMembershipParams,
+} from "./organization.types";
+import {
+    OrganizationDto,
+    SimpleOrganizationDto,
+    OrgMembershipDto,
+} from "./organization.dto";
+import {
+    mapOrganization,
+    mapSimpleOrganizations,
+    mapUpdateOrganizationParams,
+    mapOrgMembership,
+    mapUpdateOrgMembershipParams,
+} from "./organization.mapper";
+import { User } from "../users/user.types";
+import { UserDTO } from "../users/user.dto";
+import { mapUsers } from "../users/user.mapper";
+
+export class OrganizationService {
+    private readonly path: string;
+
+    constructor(private readonly client: GithubClient) {
+        this.path = `/orgs/${this.client.config.org}`;
+    }
+
+    /**
+     * Get the configured organisation
+     *
+     * @returns Data of the organisation
+     *
+     * @example
+     * ```ts
+     * const org = await github.organizations.get();
+     * ```
+     */
+    public async get(): Promise<Organization> {
+        assertConfig(this.client, ["org"]);
+        const response = await this.client.request<OrganizationDto>(this.path);
+        return mapOrganization(response.data);
+    }
+
+    /**
+     * Update the configured organisation
+     *
+     * @param params Configuration for the organisation to update
+     * @returns Data of the updated organisation
+     *
+     * @example
+     * ```ts
+     * github.organizations.update({
+     *     description: 'Developer tools, done right',
+     *     email: 'hello@lujax.dev',
+     * });
+     * ```
+     */
+    public async update(
+        params: UpdateOrganizationParams,
+    ): Promise<Organization> {
+        assertConfig(this.client, ["org"]);
+        const body = mapUpdateOrganizationParams(params);
+        const response = await this.client.request<OrganizationDto>(this.path, {
+            method: "PATCH",
+            body: JSON.stringify(body),
+        });
+        return mapOrganization(response.data);
+    }
+
+    /**
+     * List all organisations, in the order that they were created
+     *
+     * @returns Array of organisations
+     *
+     * @example
+     * ```ts
+     * const organizations = await github.organizations.list();
+     * ```
+     */
+    public async list(): Promise<SimpleOrganization[]> {
+        const response =
+            await this.client.request<SimpleOrganizationDto[]>(
+                "/organizations",
+            );
+        return mapSimpleOrganizations(response.data);
+    }
+
+    /**
+     * List organisations for a user by their username
+     *
+     * @param username The handle for the GitHub user account
+     * @returns Array of organisations
+     *
+     * @example
+     * ```ts
+     * const organizations = await github.organizations.listForUser('LewieJ08');
+     * ```
+     */
+    public async listForUser(username: string): Promise<SimpleOrganization[]> {
+        const response = await this.client.request<SimpleOrganizationDto[]>(
+            `/users/${username}/orgs`,
+        );
+        return mapSimpleOrganizations(response.data);
+    }
+
+    /**
+     * List organisations for the authenticated user
+     *
+     * @returns Array of organisations
+     *
+     * @example
+     * ```ts
+     * const organizations = await github.organizations.listForAuthenticatedUser();
+     * ```
+     */
+    public async listForAuthenticatedUser(): Promise<SimpleOrganization[]> {
+        const response =
+            await this.client.request<SimpleOrganizationDto[]>("/user/orgs");
+        return mapSimpleOrganizations(response.data);
+    }
+
+    /**
+     * List members of the configured organisation
+     *
+     * @returns Array of users
+     *
+     * @example
+     * ```ts
+     * const members = await github.organizations.listMembers();
+     * ```
+     */
+    public async listMembers(): Promise<User[]> {
+        assertConfig(this.client, ["org"]);
+        const response = await this.client.request<UserDTO[]>(
+            `${this.path}/members`,
+        );
+        return mapUsers(response.data);
+    }
+
+    /**
+     * Check if a user is a member of the configured organisation
+     *
+     * @param username The handle for the GitHub user account
+     * @returns Boolean value that determines if the user is a member
+     *
+     * @example
+     * ```ts
+     * const isMember = await github.organizations.checkMembership('LewieJ08');
+     * ```
+     */
+    public async checkMembership(username: string): Promise<boolean> {
+        assertConfig(this.client, ["org"]);
+        try {
+            const response = await this.client.request<null>(
+                `${this.path}/members/${username}`,
+            );
+            return response.status === 204;
+        } catch (error) {
+            if (error instanceof GithubApiError && error.status === 404) {
+                return false;
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * Remove a member from the configured organisation
+     *
+     * @param username The handle for the GitHub user account
+     * @returns Boolean value that determines if the member was removed
+     *
+     * @example
+     * ```ts
+     * github.organizations.removeMember('LewieJ08');
+     * ```
+     */
+    public async removeMember(username: string): Promise<boolean> {
+        assertConfig(this.client, ["org"]);
+        const response = await this.client.request<null>(
+            `${this.path}/members/${username}`,
+            { method: "DELETE" },
+        );
+        return response.status === 204;
+    }
+
+    /**
+     * Get organisation membership details for a user
+     *
+     * @param username The handle for the GitHub user account
+     * @returns Data of the organisation membership
+     *
+     * @example
+     * ```ts
+     * const membership = await github.organizations.getMembershipForUser('LewieJ08');
+     * ```
+     */
+    public async getMembershipForUser(
+        username: string,
+    ): Promise<OrgMembership> {
+        assertConfig(this.client, ["org"]);
+        const response = await this.client.request<OrgMembershipDto>(
+            `${this.path}/memberships/${username}`,
+        );
+        return mapOrgMembership(response.data);
+    }
+
+    /**
+     * Update organisation membership for a user (e.g. change their role)
+     *
+     * @param username The handle for the GitHub user account
+     * @param params Configuration for the membership to update
+     * @returns Data of the updated organisation membership
+     *
+     * @example
+     * ```ts
+     * github.organizations.updateMembershipForUser('LewieJ08', { role: 'admin' });
+     * ```
+     */
+    public async updateMembershipForUser(
+        username: string,
+        params: UpdateOrgMembershipParams,
+    ): Promise<OrgMembership> {
+        assertConfig(this.client, ["org"]);
+        const body = mapUpdateOrgMembershipParams(params);
+        const response = await this.client.request<OrgMembershipDto>(
+            `${this.path}/memberships/${username}`,
+            {
+                method: "PUT",
+                body: JSON.stringify(body),
+            },
+        );
+        return mapOrgMembership(response.data);
+    }
+
+    /**
+     * Remove organisation membership for a user
+     *
+     * @param username The handle for the GitHub user account
+     * @returns Boolean value that determines if the membership was removed
+     *
+     * @example
+     * ```ts
+     * github.organizations.removeMembershipForUser('LewieJ08');
+     * ```
+     */
+    public async removeMembershipForUser(username: string): Promise<boolean> {
+        assertConfig(this.client, ["org"]);
+        const response = await this.client.request<null>(
+            `${this.path}/memberships/${username}`,
+            { method: "DELETE" },
+        );
+        return response.status === 204;
+    }
+}

--- a/src/modules/organizations/organization.dto.ts
+++ b/src/modules/organizations/organization.dto.ts
@@ -1,3 +1,5 @@
+import { UserDTO } from "../users/user.dto";
+
 export interface SimpleOrganizationDto {
     id: number;
     login: string;
@@ -23,4 +25,13 @@ export interface OrganizationDto extends SimpleOrganizationDto {
     created_at: string;
     updated_at: string;
     archived_at?: string | null;
+}
+
+export interface OrgMembershipDto {
+    url: string;
+    state: "active" | "pending";
+    role: "admin" | "member";
+    organization_url: string;
+    organization: SimpleOrganizationDto;
+    user: UserDTO;
 }

--- a/src/modules/organizations/organization.mapper.ts
+++ b/src/modules/organizations/organization.mapper.ts
@@ -1,5 +1,18 @@
-import { OrganizationDto, SimpleOrganizationDto } from "./organization.dto";
-import { Organization, SimpleOrganization } from "./organization.types";
+import {
+    OrganizationDto,
+    SimpleOrganizationDto,
+    OrgMembershipDto,
+} from "./organization.dto";
+import {
+    Organization,
+    SimpleOrganization,
+    UpdateOrganizationParams,
+    UpdateOrganizationPayload,
+    OrgMembership,
+    UpdateOrgMembershipParams,
+    UpdateOrgMembershipPayload,
+} from "./organization.types";
+import { mapUser } from "../users/user.mapper";
 
 export function mapSimpleOrganization(
     dto: SimpleOrganizationDto,
@@ -36,5 +49,49 @@ export function mapOrganization(dto: OrganizationDto): Organization {
         createdAt: dto.created_at,
         updatedAt: dto.updated_at,
         archivedAt: dto.archived_at,
+    };
+}
+
+export function mapSimpleOrganizations(
+    dtos: SimpleOrganizationDto[],
+): SimpleOrganization[] {
+    return dtos.map(mapSimpleOrganization);
+}
+
+export function mapUpdateOrganizationParams(
+    params: UpdateOrganizationParams,
+): UpdateOrganizationPayload {
+    return {
+        billing_email: params.billingEmail,
+        company: params.company,
+        email: params.email,
+        twitter_username: params.twitterUsername,
+        location: params.location,
+        name: params.name,
+        description: params.description,
+        blog: params.blog,
+        has_organization_projects: params.hasOrganizationProjects,
+        has_repository_projects: params.hasRepositoryProjects,
+        default_repository_permission: params.defaultRepositoryPermission,
+        members_can_create_repositories: params.membersCanCreateRepositories,
+    };
+}
+
+export function mapOrgMembership(dto: OrgMembershipDto): OrgMembership {
+    return {
+        url: dto.url,
+        state: dto.state,
+        role: dto.role,
+        organizationUrl: dto.organization_url,
+        organization: mapSimpleOrganization(dto.organization),
+        user: mapUser(dto.user),
+    };
+}
+
+export function mapUpdateOrgMembershipParams(
+    params: UpdateOrgMembershipParams,
+): UpdateOrgMembershipPayload {
+    return {
+        role: params.role,
     };
 }

--- a/src/modules/organizations/organization.types.ts
+++ b/src/modules/organizations/organization.types.ts
@@ -1,3 +1,5 @@
+import { User } from "../users/user.types";
+
 export interface SimpleOrganization {
     id: number;
     login: string;
@@ -23,4 +25,57 @@ export interface Organization extends SimpleOrganization {
     createdAt: string;
     updatedAt: string;
     archivedAt?: string | null;
+}
+
+export type OrganizationRepositoryPermission =
+    "read" | "write" | "admin" | "none";
+
+export interface UpdateOrganizationParams {
+    billingEmail?: string;
+    company?: string;
+    email?: string;
+    twitterUsername?: string;
+    location?: string;
+    name?: string;
+    description?: string;
+    blog?: string;
+    hasOrganizationProjects?: boolean;
+    hasRepositoryProjects?: boolean;
+    defaultRepositoryPermission?: OrganizationRepositoryPermission;
+    membersCanCreateRepositories?: boolean;
+}
+
+export interface UpdateOrganizationPayload {
+    billing_email?: string;
+    company?: string;
+    email?: string;
+    twitter_username?: string;
+    location?: string;
+    name?: string;
+    description?: string;
+    blog?: string;
+    has_organization_projects?: boolean;
+    has_repository_projects?: boolean;
+    default_repository_permission?: OrganizationRepositoryPermission;
+    members_can_create_repositories?: boolean;
+}
+
+export type OrgMembershipRole = "admin" | "member";
+export type OrgMembershipState = "active" | "pending";
+
+export interface OrgMembership {
+    url: string;
+    state: OrgMembershipState;
+    role: OrgMembershipRole;
+    organizationUrl: string;
+    organization: SimpleOrganization;
+    user: User;
+}
+
+export interface UpdateOrgMembershipParams {
+    role?: OrgMembershipRole;
+}
+
+export interface UpdateOrgMembershipPayload {
+    role?: OrgMembershipRole;
 }

--- a/tests/unit/modules/organizations/OrganizationService.test.ts
+++ b/tests/unit/modules/organizations/OrganizationService.test.ts
@@ -1,0 +1,242 @@
+import { GithubClient } from "../../../../src/client/GithubClient";
+import { OrganizationService } from "../../../../src/modules/organizations/OrganizationService";
+import { GithubApiError } from "../../../../src/shared/errors/GithubApiError";
+import {
+    OrganizationDto,
+    SimpleOrganizationDto,
+    OrgMembershipDto,
+} from "../../../../src/modules/organizations/organization.dto";
+import { UserDTO } from "../../../../src/modules/users/user.dto";
+
+const mockUserDto: UserDTO = {
+    login: "testuser",
+    id: 1,
+    node_id: "U_1",
+    avatar_url: "",
+    html_url: "",
+    url: "",
+    type: "User",
+    site_admin: false,
+    name: null,
+    company: null,
+    blog: null,
+    location: null,
+    email: null,
+    bio: null,
+    twitter_username: null,
+    public_repos: 0,
+    public_gists: 0,
+    followers: 0,
+    following: 0,
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2020-01-01T00:00:00Z",
+};
+
+const mockSimpleOrgDto: SimpleOrganizationDto = {
+    id: 1,
+    login: "lujax-dev",
+    avatar_url: "",
+    description: null,
+    url: "https://api.github.com/orgs/lujax-dev",
+};
+
+const mockOrgDto: OrganizationDto = {
+    ...mockSimpleOrgDto,
+    node_id: "O_1",
+    public_repos: 1,
+    public_gists: 0,
+    followers: 0,
+    following: 0,
+    html_url: "https://github.com/lujax-dev",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+};
+
+const mockMembershipDto: OrgMembershipDto = {
+    url: "https://api.github.com/orgs/lujax-dev/memberships/testuser",
+    state: "active",
+    role: "admin",
+    organization_url: "https://api.github.com/orgs/lujax-dev",
+    organization: mockSimpleOrgDto,
+    user: mockUserDto,
+};
+
+function makeService() {
+    const mockRequest = jest.fn();
+    const client = {
+        config: { token: "test-token", org: "lujax-dev" },
+        request: mockRequest,
+        baseUrl: "https://api.github.com",
+    } as unknown as GithubClient;
+    return { service: new OrganizationService(client), mockRequest };
+}
+
+describe("OrganizationService", () => {
+    describe("get", () => {
+        it("calls GET /orgs/:org", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: mockOrgDto, status: 200 });
+            await service.get();
+            expect(mockRequest).toHaveBeenCalledWith("/orgs/lujax-dev");
+        });
+
+        it("returns a mapped Organization", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: mockOrgDto, status: 200 });
+            const result = await service.get();
+            expect(result.login).toBe("lujax-dev");
+        });
+    });
+
+    describe("update", () => {
+        it("calls PATCH /orgs/:org with the mapped payload", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: mockOrgDto, status: 200 });
+            await service.update({ description: "New description" });
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/orgs/lujax-dev",
+                expect.objectContaining({ method: "PATCH" }),
+            );
+        });
+    });
+
+    describe("list", () => {
+        it("calls GET /organizations", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: [mockSimpleOrgDto],
+                status: 200,
+            });
+            const result = await service.list();
+            expect(mockRequest).toHaveBeenCalledWith("/organizations");
+            expect(result).toHaveLength(1);
+        });
+    });
+
+    describe("listForUser", () => {
+        it("calls GET /users/:username/orgs", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: [mockSimpleOrgDto],
+                status: 200,
+            });
+            await service.listForUser("LewieJ08");
+            expect(mockRequest).toHaveBeenCalledWith("/users/LewieJ08/orgs");
+        });
+    });
+
+    describe("listForAuthenticatedUser", () => {
+        it("calls GET /user/orgs", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: [mockSimpleOrgDto],
+                status: 200,
+            });
+            await service.listForAuthenticatedUser();
+            expect(mockRequest).toHaveBeenCalledWith("/user/orgs");
+        });
+    });
+
+    describe("listMembers", () => {
+        it("calls GET /orgs/:org/members", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: [mockUserDto],
+                status: 200,
+            });
+            const result = await service.listMembers();
+            expect(mockRequest).toHaveBeenCalledWith("/orgs/lujax-dev/members");
+            expect(result[0].username).toBe("testuser");
+        });
+    });
+
+    describe("checkMembership", () => {
+        it("returns true on 204", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: null, status: 204 });
+            const result = await service.checkMembership("testuser");
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/orgs/lujax-dev/members/testuser",
+            );
+            expect(result).toBe(true);
+        });
+
+        it("returns false on 404", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockRejectedValue(new GithubApiError(404, "Not Found"));
+            const result = await service.checkMembership("testuser");
+            expect(result).toBe(false);
+        });
+
+        it("rethrows non-404 GithubApiErrors", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockRejectedValue(
+                new GithubApiError(500, "Server error"),
+            );
+            await expect(service.checkMembership("testuser")).rejects.toThrow(
+                GithubApiError,
+            );
+        });
+    });
+
+    describe("removeMember", () => {
+        it("calls DELETE /orgs/:org/members/:username", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: null, status: 204 });
+            const result = await service.removeMember("testuser");
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/orgs/lujax-dev/members/testuser",
+                { method: "DELETE" },
+            );
+            expect(result).toBe(true);
+        });
+    });
+
+    describe("getMembershipForUser", () => {
+        it("calls GET /orgs/:org/memberships/:username", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: mockMembershipDto,
+                status: 200,
+            });
+            const result = await service.getMembershipForUser("testuser");
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/orgs/lujax-dev/memberships/testuser",
+            );
+            expect(result.role).toBe("admin");
+        });
+    });
+
+    describe("updateMembershipForUser", () => {
+        it("calls PUT /orgs/:org/memberships/:username with the mapped payload", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({
+                data: mockMembershipDto,
+                status: 200,
+            });
+            await service.updateMembershipForUser("testuser", {
+                role: "admin",
+            });
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/orgs/lujax-dev/memberships/testuser",
+                {
+                    method: "PUT",
+                    body: JSON.stringify({ role: "admin" }),
+                },
+            );
+        });
+    });
+
+    describe("removeMembershipForUser", () => {
+        it("calls DELETE /orgs/:org/memberships/:username", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: null, status: 204 });
+            const result = await service.removeMembershipForUser("testuser");
+            expect(mockRequest).toHaveBeenCalledWith(
+                "/orgs/lujax-dev/memberships/testuser",
+                { method: "DELETE" },
+            );
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/tests/unit/modules/organizations/organization.mapper.test.ts
+++ b/tests/unit/modules/organizations/organization.mapper.test.ts
@@ -1,0 +1,134 @@
+import {
+    mapSimpleOrganization,
+    mapOrganization,
+    mapSimpleOrganizations,
+    mapUpdateOrganizationParams,
+    mapOrgMembership,
+    mapUpdateOrgMembershipParams,
+} from "../../../../src/modules/organizations/organization.mapper";
+import {
+    SimpleOrganizationDto,
+    OrganizationDto,
+    OrgMembershipDto,
+} from "../../../../src/modules/organizations/organization.dto";
+import { UserDTO } from "../../../../src/modules/users/user.dto";
+
+const mockUserDto: UserDTO = {
+    login: "testuser",
+    id: 1,
+    node_id: "U_1",
+    avatar_url: "",
+    html_url: "",
+    url: "",
+    type: "User",
+    site_admin: false,
+    name: null,
+    company: null,
+    blog: null,
+    location: null,
+    email: null,
+    bio: null,
+    twitter_username: null,
+    public_repos: 0,
+    public_gists: 0,
+    followers: 0,
+    following: 0,
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2020-01-01T00:00:00Z",
+};
+
+const mockSimpleOrgDto: SimpleOrganizationDto = {
+    id: 1,
+    login: "lujax-dev",
+    avatar_url: "https://avatars.githubusercontent.com/u/1",
+    description: "Developer tools, done right",
+    url: "https://api.github.com/orgs/lujax-dev",
+};
+
+const mockOrgDto: OrganizationDto = {
+    ...mockSimpleOrgDto,
+    node_id: "O_1",
+    name: "Lujax",
+    company: undefined,
+    blog: "https://lujax.dev",
+    location: "London, UK",
+    email: "hello@lujax.dev",
+    twitter_username: null,
+    is_verified: false,
+    public_repos: 1,
+    public_gists: 0,
+    followers: 0,
+    following: 0,
+    html_url: "https://github.com/lujax-dev",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    archived_at: null,
+};
+
+describe("organization.mapper", () => {
+    describe("mapSimpleOrganization", () => {
+        it("maps avatar_url to avatarUrl", () => {
+            const result = mapSimpleOrganization(mockSimpleOrgDto);
+            expect(result.avatarUrl).toBe(mockSimpleOrgDto.avatar_url);
+            expect(result.login).toBe("lujax-dev");
+        });
+    });
+
+    describe("mapOrganization", () => {
+        it("maps snake_case fields to camelCase", () => {
+            const result = mapOrganization(mockOrgDto);
+            expect(result.nodeId).toBe("O_1");
+            expect(result.twitterUsername).toBeNull();
+            expect(result.isVerified).toBe(false);
+            expect(result.htmlUrl).toBe("https://github.com/lujax-dev");
+            expect(result.archivedAt).toBeNull();
+        });
+    });
+
+    describe("mapSimpleOrganizations", () => {
+        it("maps an array of organizations", () => {
+            const result = mapSimpleOrganizations([mockSimpleOrgDto]);
+            expect(result).toHaveLength(1);
+            expect(result[0].login).toBe("lujax-dev");
+        });
+    });
+
+    describe("mapUpdateOrganizationParams", () => {
+        it("maps camelCase params to snake_case payload", () => {
+            const result = mapUpdateOrganizationParams({
+                billingEmail: "billing@lujax.dev",
+                defaultRepositoryPermission: "read",
+                membersCanCreateRepositories: false,
+            });
+            expect(result.billing_email).toBe("billing@lujax.dev");
+            expect(result.default_repository_permission).toBe("read");
+            expect(result.members_can_create_repositories).toBe(false);
+        });
+    });
+
+    describe("mapOrgMembership", () => {
+        it("maps a membership DTO to camelCase", () => {
+            const dto: OrgMembershipDto = {
+                url: "https://api.github.com/orgs/lujax-dev/memberships/testuser",
+                state: "active",
+                role: "admin",
+                organization_url: "https://api.github.com/orgs/lujax-dev",
+                organization: mockSimpleOrgDto,
+                user: mockUserDto,
+            };
+            const result = mapOrgMembership(dto);
+            expect(result.organizationUrl).toBe(dto.organization_url);
+            expect(result.role).toBe("admin");
+            expect(result.state).toBe("active");
+            expect(result.user.username).toBe("testuser");
+            expect(result.organization.login).toBe("lujax-dev");
+        });
+    });
+
+    describe("mapUpdateOrgMembershipParams", () => {
+        it("passes role through", () => {
+            const result = mapUpdateOrgMembershipParams({ role: "member" });
+            expect(result.role).toBe("member");
+        });
+    });
+});


### PR DESCRIPTION
## What's in this PR

Finishes the previously-orphaned Organizations module — types/dto/mapper
already existed, no service, not wired into GithubClient.

Full endpoint coverage, `github.organizations`:
- `get()` / `update(params)` — org read/write
- `list()` / `listForUser(username)` / `listForAuthenticatedUser()` — listings
- `listMembers()` / `checkMembership(username)` / `removeMember(username)`
- `getMembershipForUser(username)` / `updateMembershipForUser(username, params)` / `removeMembershipForUser(username)`

New types: `UpdateOrganizationParams`/`Payload`, `OrgMembership`,
`UpdateOrgMembershipParams`/`Payload`. `checkMembership()` follows the same
204/404-to-boolean pattern as `PullRequestService.isMerged()`.

## Why

Closes #66. Orphaned module discovered mid-v1 — never one of the original
20 tracked issues, but worth doing properly since it adds real value for
future Lujax Hub health/governance signals.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 109 tests passing (20 new: service + previously-untested mapper)
- [x] `npm run format:check` clean

Closes #66