### PR TITLE
Add GitHub Actions CI and npm publish workflows (closes #55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+    push:
+        branches: [dev, main]
+    pull_request:
+        branches: [main]
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [18.x, 20.x]
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: npm
+
+            - run: npm ci
+            - run: npm run build
+            - run: npm test
+            - run: npm run format:check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+    push:
+        tags:
+            - "v*"
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+                  registry-url: https://registry.npmjs.org
+
+            - run: npm ci
+            - run: npm run build
+            - run: npm test
+            - run: npm run format:check
+
+            - run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "files": [
         "dist"
     ],
+    "publishConfig": {
+        "access": "public"
+    },
     "scripts": {
         "build": "tsc -p tsconfig.build.json",
         "prepublishOnly": "npm run build",


### PR DESCRIPTION
Adds the two workflows the project needs before it can ship:

- `ci.yml` — build, test, and format:check on a Node 18.x/20.x matrix
  (matrix chosen to match the README's "Node.js 18 or later" claim).
  Triggers on PRs into main and pushes to dev/main, so failures surface
  during day-to-day work on dev, not just at the dev→main merge point.
- `publish.yml` — same checks, then `npm publish` on a `v*` tag push,
  using `NODE_AUTH_TOKEN`/`secrets.NPM_TOKEN`.

Also found and fixed a real gap while building this: `@lujax/github-sdk`
is a scoped package, and npm defaults scoped packages to private —
the first publish would fail outright without `publishConfig.access:
"public"` in package.json. Added it so both the CI path and any future
manual `npm publish` are covered.

Note: the publish workflow can't be exercised end-to-end yet — it
depends on the `@lujax` npm org being verified/claimed and an
`NPM_TOKEN` secret being added to the repo (both still open Lujax-level
action items, not part of this PR).

Closes #55