### PR TITLE
Change error message prefix to @lujax/github-sdk (closes #57)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/shared/errors/GithubSdkError.ts
+++ b/src/shared/errors/GithubSdkError.ts
@@ -2,8 +2,8 @@ export class GithubSdkError extends Error {
     public readonly exitCode: number;
 
     constructor(message: string, exitCode: number = 1) {
-        super(`github-sdk: ${message}`);
+        super(`@lujax/github-sdk: ${message}`);
         this.exitCode = exitCode;
-        this.name = "GithubSDKError";
+        this.name = "GithubSdkError";
     }
 }

--- a/tests/unit/shared/errors/GithubApiError.test.ts
+++ b/tests/unit/shared/errors/GithubApiError.test.ts
@@ -1,0 +1,41 @@
+import { GithubApiError } from "../../../../src/shared/errors/GithubApiError";
+import { GithubSdkError } from "../../../../src/shared/errors/GithubSdkError";
+
+describe("GithubApiError", () => {
+    it("includes the status and message", () => {
+        const error = new GithubApiError(404, "Not Found");
+        expect(error.message).toBe(
+            "@lujax/github-sdk: GitHub API error (404): Not Found",
+        );
+        expect(error.status).toBe(404);
+    });
+
+    it("sets name to GithubApiError", () => {
+        const error = new GithubApiError(404, "Not Found");
+        expect(error.name).toBe("GithubApiError");
+    });
+
+    it("carries documentationUrl and details when provided", () => {
+        const error = new GithubApiError(
+            422,
+            "Validation Failed",
+            "https://docs.github.com/rest",
+            {
+                field: "name",
+            },
+        );
+        expect(error.documentationUrl).toBe("https://docs.github.com/rest");
+        expect(error.details).toEqual({ field: "name" });
+    });
+
+    it("leaves documentationUrl and details undefined when omitted", () => {
+        const error = new GithubApiError(500, "Server Error");
+        expect(error.documentationUrl).toBeUndefined();
+        expect(error.details).toBeUndefined();
+    });
+
+    it("is an instance of GithubSdkError", () => {
+        const error = new GithubApiError(404, "Not Found");
+        expect(error).toBeInstanceOf(GithubSdkError);
+    });
+});

--- a/tests/unit/shared/errors/GithubSdkError.test.ts
+++ b/tests/unit/shared/errors/GithubSdkError.test.ts
@@ -1,0 +1,28 @@
+import { GithubSdkError } from "../../../../src/shared/errors/GithubSdkError";
+
+describe("GithubSdkError", () => {
+    it("prefixes the message with the package name", () => {
+        const error = new GithubSdkError("something went wrong");
+        expect(error.message).toBe("@lujax/github-sdk: something went wrong");
+    });
+
+    it("defaults exitCode to 1", () => {
+        const error = new GithubSdkError("something went wrong");
+        expect(error.exitCode).toBe(1);
+    });
+
+    it("accepts a custom exitCode", () => {
+        const error = new GithubSdkError("something went wrong", 2);
+        expect(error.exitCode).toBe(2);
+    });
+
+    it("sets name to GithubSdkError", () => {
+        const error = new GithubSdkError("something went wrong");
+        expect(error.name).toBe("GithubSdkError");
+    });
+
+    it("is an instance of Error", () => {
+        const error = new GithubSdkError("something went wrong");
+        expect(error).toBeInstanceOf(Error);
+    });
+});

--- a/tests/unit/shared/errors/InvalidTokenError.test.ts
+++ b/tests/unit/shared/errors/InvalidTokenError.test.ts
@@ -1,0 +1,19 @@
+import { InvalidTokenError } from "../../../../src/shared/errors/InvalidTokenError";
+import { GithubSdkError } from "../../../../src/shared/errors/GithubSdkError";
+
+describe("InvalidTokenError", () => {
+    it("has a fixed message", () => {
+        const error = new InvalidTokenError();
+        expect(error.message).toBe("@lujax/github-sdk: Invalid GitHub Token");
+    });
+
+    it("sets name to InvalidTokenError", () => {
+        const error = new InvalidTokenError();
+        expect(error.name).toBe("InvalidTokenError");
+    });
+
+    it("is an instance of GithubSdkError", () => {
+        const error = new InvalidTokenError();
+        expect(error).toBeInstanceOf(GithubSdkError);
+    });
+});

--- a/tests/unit/shared/errors/MissingConfigError.test.ts
+++ b/tests/unit/shared/errors/MissingConfigError.test.ts
@@ -1,0 +1,21 @@
+import { MissingConfigError } from "../../../../src/shared/errors/MissingConfigError";
+import { GithubSdkError } from "../../../../src/shared/errors/GithubSdkError";
+
+describe("MissingConfigError", () => {
+    it("lists the missing properties in the message", () => {
+        const error = new MissingConfigError(["owner", "repo"]);
+        expect(error.message).toBe(
+            "@lujax/github-sdk: GithubClient is missing service dependent config properties: owner,repo",
+        );
+    });
+
+    it("sets name to MissingConfigError", () => {
+        const error = new MissingConfigError(["owner"]);
+        expect(error.name).toBe("MissingConfigError");
+    });
+
+    it("is an instance of GithubSdkError", () => {
+        const error = new MissingConfigError(["owner"]);
+        expect(error).toBeInstanceOf(GithubSdkError);
+    });
+});

--- a/tests/unit/shared/utils/config.utils.test.ts
+++ b/tests/unit/shared/utils/config.utils.test.ts
@@ -1,0 +1,31 @@
+import { assertConfig } from "../../../../src/shared/utils/config.utils";
+import {
+    GithubClient,
+    GithubClientConfig,
+} from "../../../../src/client/GithubClient";
+import { MissingConfigError } from "../../../../src/shared/errors/MissingConfigError";
+
+function fakeClient(config: GithubClientConfig): GithubClient {
+    return { config } as GithubClient;
+}
+
+describe("assertConfig", () => {
+    it("does not throw when all required keys are present", () => {
+        const client = fakeClient({ owner: "lujax-dev", repo: "github-sdk" });
+        expect(() => assertConfig(client, ["owner", "repo"])).not.toThrow();
+    });
+
+    it("throws MissingConfigError when a required key is absent", () => {
+        const client = fakeClient({});
+        expect(() => assertConfig(client, ["owner", "repo"])).toThrow(
+            MissingConfigError,
+        );
+    });
+
+    it("throws MissingConfigError when a required key is an empty string", () => {
+        const client = fakeClient({ owner: "" });
+        expect(() => assertConfig(client, ["owner"])).toThrow(
+            MissingConfigError,
+        );
+    });
+});


### PR DESCRIPTION
GithubSdkError prefixed every error message with "github-sdk: ...", left over from before the package was renamed to @lujax/github-sdk (#38). Changed to match the actual npm package name.

 - Fixed a latent typo found in the same file: this.name was "GithubSDKError" instead of "GithubSdkError" — harmless (never instantiated directly) but corrected while there
 - Added the first unit tests for all four error classes and assertConfig, closing test-coverage gaps flagged in _notes/sdk-status.md
 - Added .gitattributes (* text=auto eol=lf) to fix local CRLF drift on Windows checkouts, flagged since 2026-07-03

npm run build clean, npm test 128/128, prettier --check clean.

Closes #57