### PR TITLE
Add CONTRIBUTING.md, /examples, and fix JSDoc bugs (closes #56)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to @lujax/github-sdk
+
+Thanks for taking a look. This project favours small, consistent, well-tested changes over clever ones — the notes below explain the conventions so a PR doesn't need a design discussion before it can be reviewed.
+
+## Setup
+
+```bash
+git clone https://github.com/lujax-dev/github-sdk.git
+cd github-sdk
+npm install
+```
+
+Useful scripts:
+
+```bash
+npm run build          # tsc -> dist/
+npm test               # Jest unit + integration tests
+npm run test:coverage  # coverage report
+npm run format          # prettier --write
+npm run format:check    # prettier --check (what CI runs)
+```
+
+Integration tests hit the real GitHub API and are skipped automatically unless `GITHUB_TEST_TOKEN`, `GITHUB_TEST_OWNER`, and `GITHUB_TEST_REPO` are set (see `.env.example`). You don't need these to work on unit tests, mappers, or docs.
+
+## The four-file module pattern
+
+Every domain module under `src/modules/<name>/` follows the same four files:
+
+| File               | Purpose                                                                      |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `<name>.types.ts`  | Clean, camelCase TypeScript interfaces exposed to consumers                  |
+| `<name>.dto.ts`    | Raw GitHub API response shapes — snake_case, mirrors the JSON exactly        |
+| `<name>.mapper.ts` | Pure functions mapping DTO → type (and, for mutations, `Params` → `Payload`) |
+| `<Name>Service.ts` | Public service class with JSDoc'd methods, wired into `GithubClient`         |
+
+For mutating endpoints (POST/PATCH/PUT), `types.ts` also has a `Payload` interface for the snake_case request body, and the mapper converts the camelCase `Params` a caller passes into it. Never send a `Params` object straight to `fetch` — always go through the mapper.
+
+Look at `src/modules/issues/` for a complete, uncomplicated example of the pattern before starting a new module.
+
+## Conventions
+
+- **TypeScript strict mode, no `any`.** Use `unknown` and narrow, or define a real type.
+- **camelCase types, snake_case DTOs.** Don't let snake_case leak into a `.types.ts` file, and don't let camelCase leak into a `.dto.ts` file.
+- **JSDoc every public method** with a one-line summary, `@param` for each parameter, `@returns`, and a runnable `@example`. Copy-paste the example and make sure it would actually compile — a broken example is worse than no example.
+- **Errors, not raw responses.** All non-2xx API responses already throw `GithubApiError` via `request.utils.ts` — don't add ad-hoc error handling in a service unless you're deliberately catching a specific status (see `PullRequestService.isMerged()` for the 404-to-`false` pattern).
+- **`assertConfig`** — if a service needs `owner`, `repo`, or `org`, call `assertConfig(this.client, [...])` at the top of the constructor (or the method, for methods that need a different key than the rest of the service — see `RepositoryService`'s org-scoped methods).
+
+## Tests
+
+Write tests alongside the code, not after it. For a new module:
+
+- `tests/unit/modules/<name>/<name>.mapper.test.ts` — given a raw DTO fixture, assert the mapped type's fields are correct
+- `tests/unit/modules/<name>/<Name>Service.test.ts` — mock `GithubClient.request`, assert the correct path, HTTP method, and body are sent
+
+Never mock the GitHub API in `tests/integration/` — those tests exist specifically to prove the SDK works against real responses. Mock `GithubClient.request` in unit tests instead.
+
+## Pull requests
+
+- Work happens on `dev`; `main` only updates via a `dev` → `main` PR.
+- Keep a PR scoped to one issue (or a small, genuinely coupled group). Don't bundle unrelated changes.
+- Reference the issue it closes (`closes #NN`) in the PR description.
+- Before opening a PR: `npm run build`, `npm test`, and `npm run format:check` should all be clean.
+
+## Reporting bugs / requesting features
+
+Open a GitHub issue. For a bug, include the method called, the params passed, and what you expected vs. what happened. For a feature request, a real use case helps more than a spec — this SDK grows based on what its actual consumers (the Lujax MCP server, CLI, and Hub, plus outside users) need, not speculative API surface.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Each service is scoped to the `owner`/`repo`/`org` set on the client and exposed
 
 There's no standalone commits service — list commits on a PR via `github.pullRequests.listCommits(pullNumber)`.
 
-Every public method has JSDoc with a runnable example — full signatures are in the source, e.g. [`PullRequestService.ts`](src/modules/pull-requests/PullRequestService.ts), [`RepositoryService.ts`](src/modules/repositories/RepositoryService.ts).
+Every public method has JSDoc with a runnable example — full signatures are in the source, e.g. [`PullRequestService.ts`](src/modules/pull-requests/PullRequestService.ts), [`RepositoryService.ts`](src/modules/repositories/RepositoryService.ts). For complete standalone scripts, see [`/examples`](examples).
 
 ## Error handling
 
@@ -120,6 +120,10 @@ Built into every request, with no configuration needed:
 - **Rate limiting** — proactively waits out the reset window when `x-ratelimit-remaining` hits 0, instead of letting requests fail with a 403
 - **Retries** — 3 attempts with 1s/2s/4s backoff on `5xx` and `429` responses
 - **ETag caching** — repeat `GET`s send `If-None-Match`; a `304` returns the cached body for free and doesn't count against your rate limit
+
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup, the module pattern, and the PR process.
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# Examples
+
+Real-world usage scripts. Each one is a standalone `.ts` file you can run directly.
+
+## Running
+
+These scripts import from `@lujax/github-sdk` as if it were installed from npm — they aren't wired into this repo's own build. To run one:
+
+```bash
+npm install @lujax/github-sdk
+npx tsx examples/basic-usage.ts
+```
+
+(`npx tsx` runs a TypeScript file directly without a separate compile step and without adding a permanent dependency to your project. `ts-node examples/basic-usage.ts` works the same way if you already use it.)
+
+Set these environment variables first (a Personal Access Token is the quickest way to try these out — see the main [README](../README.md#authentication) for GitHub App auth):
+
+```bash
+export GITHUB_TOKEN=ghp_xxxxxxxxxxxx
+export GITHUB_OWNER=your-username-or-org
+export GITHUB_REPO=your-repo-name
+```
+
+## Scripts
+
+| File                                       | What it shows                                                   |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| [`basic-usage.ts`](basic-usage.ts)         | Constructing a client and calling a couple of read-only methods |
+| [`list-prs.ts`](list-prs.ts)               | Listing pull requests and printing their cycle time             |
+| [`manage-releases.ts`](manage-releases.ts) | Creating a release, then updating and deleting it               |

--- a/examples/basic-usage.ts
+++ b/examples/basic-usage.ts
@@ -1,0 +1,27 @@
+/**
+ * Construct a client and call a couple of read-only methods.
+ * Run with: npx tsx examples/basic-usage.ts
+ */
+import { GithubClient } from "@lujax/github-sdk";
+
+async function main() {
+    const github = new GithubClient({
+        token: process.env.GITHUB_TOKEN,
+        owner: process.env.GITHUB_OWNER,
+        repo: process.env.GITHUB_REPO,
+    });
+
+    const repo = await github.repositories.get();
+    console.log(`${repo.fullName}: ${repo.description ?? "(no description)"}`);
+    console.log(
+        `Stars: ${repo.stargazersCount} · Open issues: ${repo.openIssuesCount}`,
+    );
+
+    const user = await github.users.getAuthenticated();
+    console.log(`Authenticated as: ${user.login}`);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/examples/list-prs.ts
+++ b/examples/list-prs.ts
@@ -1,0 +1,29 @@
+/**
+ * List pull requests and print each one's cycle time (open -> merge duration).
+ * Run with: npx tsx examples/list-prs.ts
+ */
+import { GithubClient } from "@lujax/github-sdk";
+
+async function main() {
+    const github = new GithubClient({
+        token: process.env.GITHUB_TOKEN,
+        owner: process.env.GITHUB_OWNER,
+        repo: process.env.GITHUB_REPO,
+    });
+
+    const pullRequests = await github.pullRequests.list();
+
+    for (const pr of pullRequests) {
+        const cycleTime = await github.pullRequests.cycleTime(pr.number);
+        const status = pr.isMerged
+            ? `merged in ${cycleTime.totalHours?.toFixed(1)}h`
+            : "still open";
+
+        console.log(`#${pr.number} ${pr.title} — ${status}`);
+    }
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/examples/manage-releases.ts
+++ b/examples/manage-releases.ts
@@ -1,0 +1,38 @@
+/**
+ * Create a release, update it, then delete it.
+ * Run with: npx tsx examples/manage-releases.ts
+ *
+ * Note: this actually creates and deletes a release on the configured repo —
+ * point GITHUB_REPO at a throwaway/test repo before running it.
+ */
+import { GithubClient } from "@lujax/github-sdk";
+
+async function main() {
+    const github = new GithubClient({
+        token: process.env.GITHUB_TOKEN,
+        owner: process.env.GITHUB_OWNER,
+        repo: process.env.GITHUB_REPO,
+    });
+
+    const release = await github.releases.create({
+        tagName: `example-${Date.now()}`,
+        name: "Example release",
+        body: "Created by examples/manage-releases.ts",
+        draft: true,
+    });
+    console.log(`Created release ${release.id} (${release.tagName})`);
+
+    const updated = await github.releases.update({
+        releaseId: release.id,
+        body: "Updated by examples/manage-releases.ts",
+    });
+    console.log(`Updated release ${updated.id}: ${updated.body}`);
+
+    await github.releases.delete(release.id);
+    console.log(`Deleted release ${release.id}`);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/src/modules/pull-requests/PullRequestService.ts
+++ b/src/modules/pull-requests/PullRequestService.ts
@@ -108,7 +108,7 @@ export class PullRequestService {
      *     pullNumber: 8,
      *     title: 'new title',
      *     body: 'updated body',
-     *     state: 'open'
+     *     state: 'open',
      *     base: 'main'
      * });
      * ```
@@ -225,7 +225,7 @@ export class PullRequestService {
      *
      * @example
      * ```ts
-     * github.pullRequests.updateBranch(8, 6dcb09b5b57875f334f61aebed695e2e4193db5e);
+     * github.pullRequests.updateBranch(8, '6dcb09b5b57875f334f61aebed695e2e4193db5e');
      * ```
      */
     public async updateBranch(

--- a/src/modules/repositories/RepositoryService.ts
+++ b/src/modules/repositories/RepositoryService.ts
@@ -314,7 +314,7 @@ export class RepositoryService {
     }
 
     /**
-     * Enable immutable releases for the configured
+     * Enable immutable releases for the configured repository
      *
      * @returns Boolean value that determines if immutable releases were enabled
      *
@@ -335,7 +335,7 @@ export class RepositoryService {
     }
 
     /**
-     * Disable immutable releases for the configured
+     * Disable immutable releases for the configured repository
      *
      * @returns Boolean value that determines if immutable releases were disabled
      *
@@ -395,7 +395,7 @@ export class RepositoryService {
     /**
      * Enable private vulnerability reporting for the configured repository
      *
-     * @returns Boolean that determines if private vulnerability reporting
+     * @returns Boolean that determines if private vulnerability reporting was enabled
      *
      * @example
      * ```ts
@@ -416,7 +416,7 @@ export class RepositoryService {
     /**
      * Disable private vulnerability reporting for the configured repository
      *
-     * @returns Boolean that determines if private vulnerability reporting
+     * @returns Boolean that determines if private vulnerability reporting was disabled
      *
      * @example
      * ```ts
@@ -477,7 +477,7 @@ export class RepositoryService {
      *
      * @example
      * ```ts
-     * const topics = await github.repositories.
+     * const topics = await github.repositories.getTopics();
      * ```
      */
     public async getTopics(): Promise<string[]> {
@@ -568,7 +568,7 @@ export class RepositoryService {
      * github.repositories.enableVulnerabilityAlerts();
      * ```
      */
-    public async enableVulnerabilityAlerts() {
+    public async enableVulnerabilityAlerts(): Promise<boolean> {
         assertConfig(this.client, ["owner", "repo"]);
         const response = await this.client.request<null>(
             `${this.path}/vulnerability-alerts`,
@@ -695,12 +695,12 @@ export class RepositoryService {
     /**
      * List repositories for a user by their username
      *
-     * @param username
+     * @param username Username of the account to list repositories for
      * @returns Array of repositories
      *
      * @example
      * ```ts
-     * const repos = await github.repositories.listForUser('LewieJ08');
+     * const repos = await github.repositories.listByUsername('LewieJ08');
      * ```
      */
     public async listByUsername(username: string): Promise<Repository[]> {


### PR DESCRIPTION
Adds CONTRIBUTING.md (setup, four-file module pattern, PR process) and three runnable example scripts (basic-usage, list-prs, manage-releases).

While auditing JSDoc for completeness, found and fixed several real bugs in existing doc comments rather than just gaps:
- RepositoryService.getTopics() example was a dangling, cut-off line
- Two @returns descriptions were truncated mid-sentence (enable/disablePrivateVulnerabilityReporting)
- Two summaries were truncated ("...for the configured" with no noun) (enable/disableImmutableReleases)
- listByUsername()'s example called a method name that doesn't exist (listForUser instead of listByUsername)
- PullRequestService.update()'s example was missing a comma, making it invalid to copy-paste
- PullRequestService.updateBranch()'s example passed an unquoted SHA, which is a syntax error as written

Also added an explicit Promise<boolean> return type to enableVulnerabilityAlerts() for consistency with every other method in the file (previously relied on inference).

npm run build clean, npm test 128/128, prettier --check clean.

closes #56 