### PR TITLE
Fix public API naming typos: Contributor and disableVulnerabilityAlerts

### DIFF
--- a/src/modules/repositories/RepositoryService.ts
+++ b/src/modules/repositories/RepositoryService.ts
@@ -11,7 +11,7 @@ import {
     mapTransferRepositoryParams,
     mapUpdateRepositoryParams,
 } from "./repository.mapper";
-import { mapContributers } from "../users/user.mapper";
+import { mapContributors } from "../users/user.mapper";
 import {
     Repository,
     CreateRepositoryParams,
@@ -36,8 +36,8 @@ import {
     RepositoryTagDTO,
     TeamDTO,
 } from "./repository.dto";
-import { Contributer } from "../users/user.types";
-import { ContributerDTO } from "../users/user.dto";
+import { Contributor } from "../users/user.types";
+import { ContributorDTO } from "../users/user.dto";
 import { assertConfig } from "../../shared/utils/config.utils";
 
 export class RepositoryService {
@@ -255,21 +255,21 @@ export class RepositoryService {
     }
 
     /**
-     * Get all contributers of the configured repository
+     * Get all contributors of the configured repository
      *
      * @returns Array of contributors
      *
      * @example
      * ```ts
-     * const contributers = await github.repositories.getContributers();
+     * const contributors = await github.repositories.getContributors();
      * ```
      */
-    public async getContributers(): Promise<Contributer[]> {
+    public async getContributors(): Promise<Contributor[]> {
         assertConfig(this.client, ["owner", "repo"]);
-        const response = await this.client.request<ContributerDTO[]>(
+        const response = await this.client.request<ContributorDTO[]>(
             `${this.path}/contributors`,
         );
-        return mapContributers(response.data);
+        return mapContributors(response.data);
     }
 
     /**
@@ -586,10 +586,10 @@ export class RepositoryService {
      *
      * @example
      * ```ts
-     * github.repositories.disableVulnerbilityAlerts();
+     * github.repositories.disableVulnerabilityAlerts();
      * ```
      */
-    public async disableVulnerbilityAlerts(): Promise<boolean> {
+    public async disableVulnerabilityAlerts(): Promise<boolean> {
         assertConfig(this.client, ["owner", "repo"]);
         const response = await this.client.request(
             `${this.path}/vulnerability-alerts`,

--- a/src/modules/users/user.dto.ts
+++ b/src/modules/users/user.dto.ts
@@ -22,6 +22,6 @@ export interface UserDTO {
     updated_at: string;
 }
 
-export interface ContributerDTO extends UserDTO {
+export interface ContributorDTO extends UserDTO {
     contributions: number;
 }

--- a/src/modules/users/user.mapper.ts
+++ b/src/modules/users/user.mapper.ts
@@ -2,9 +2,9 @@ import {
     UpdateUserParams,
     UpdateUserPayload,
     User,
-    Contributer,
+    Contributor,
 } from "./user.types";
-import { UserDTO, ContributerDTO } from "./user.dto";
+import { UserDTO, ContributorDTO } from "./user.dto";
 
 export function mapUser(dto: UserDTO): User {
     return {
@@ -35,7 +35,7 @@ export function mapUsers(dtos: UserDTO[]): User[] {
     return dtos.map((dto) => mapUser(dto));
 }
 
-export function mapContributer(dto: ContributerDTO): Contributer {
+export function mapContributor(dto: ContributorDTO): Contributor {
     return {
         username: dto.login,
         id: dto.id,
@@ -61,8 +61,8 @@ export function mapContributer(dto: ContributerDTO): Contributer {
     };
 }
 
-export function mapContributers(dtos: ContributerDTO[]): Contributer[] {
-    return dtos.map((dto) => mapContributer(dto));
+export function mapContributors(dtos: ContributorDTO[]): Contributor[] {
+    return dtos.map((dto) => mapContributor(dto));
 }
 
 export function mapUpdateUserParams(

--- a/src/modules/users/user.types.ts
+++ b/src/modules/users/user.types.ts
@@ -21,7 +21,7 @@ export interface User {
     updatedAt: string;
 }
 
-export interface Contributer extends User {
+export interface Contributor extends User {
     contributions: number;
 }
 


### PR DESCRIPTION
RepositoryService.getContributers() and its supporting Contributer type, ContributerDTO, and mapContributers/mapContributor functions were misspelled since first built. disableVulnerbilityAlerts() was also missing an 'a'.

Fixing now while pre-publish costs nothing; after v1.0.0 ships these become breaking changes. No test referenced either old name, confirming both methods were part of the known RepositoryService coverage gap.

npm run build clean, npm test 128/128, prettier --check clean.