### PR TITLE
Fix UserService.getById() wrong endpoint and broken example

### DIFF
--- a/examples/basic-usage.ts
+++ b/examples/basic-usage.ts
@@ -18,7 +18,7 @@ async function main() {
     );
 
     const user = await github.users.getAuthenticated();
-    console.log(`Authenticated as: ${user.login}`);
+    console.log(`Authenticated as: ${user.username}`);
 }
 
 main().catch((error) => {

--- a/src/modules/users/UserService.ts
+++ b/src/modules/users/UserService.ts
@@ -65,7 +65,7 @@ export class UserService {
      */
     public async getById(accountId: number): Promise<User> {
         const response = await this.client.request<UserDTO>(
-            `${this.path}/${accountId}`,
+            `${this.authPath}/${accountId}`,
         );
         return mapUser(response.data);
     }

--- a/tests/unit/modules/users/UserService.test.ts
+++ b/tests/unit/modules/users/UserService.test.ts
@@ -76,11 +76,18 @@ describe("UserService", () => {
     });
 
     describe("getById", () => {
-        it("calls GET /users/:id", async () => {
+        it("calls GET /user/:id, not /users/:id", async () => {
             const { service, mockRequest } = makeService();
             mockRequest.mockResolvedValue({ data: mockUserDto, status: 200 });
             await service.getById(42);
-            expect(mockRequest).toHaveBeenCalledWith("/users/42");
+            expect(mockRequest).toHaveBeenCalledWith("/user/42");
+        });
+
+        it("returns mapped User", async () => {
+            const { service, mockRequest } = makeService();
+            mockRequest.mockResolvedValue({ data: mockUserDto, status: 200 });
+            const result = await service.getById(42);
+            expect(result.username).toBe("testuser");
         });
     });
 


### PR DESCRIPTION
getById() called GET /users/{id}, but GitHub's actual "get a user by ID" endpoint is GET /user/{id} (singular - confirmed against GitHub's REST API docs). Every real call was hitting the wrong URL; the existing unit test asserted the buggy path so nothing caught it.

Also fixed examples/basic-usage.ts, which referenced user.login - a field that doesn't exist on the User type (it's username). examples/ isn't included in any tsconfig, so this never got caught by build or CI.