### PR TITLE
Add LICENSE file and npm package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lewie Jackson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,21 @@
     "files": [
         "dist"
     ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lujax-dev/github-sdk.git"
+    },
+    "homepage": "https://github.com/lujax-dev/github-sdk#readme",
+    "bugs": {
+        "url": "https://github.com/lujax-dev/github-sdk/issues"
+    },
+    "author": {
+        "name": "Lewie Jackson",
+        "url": "https://github.com/LewieJ08"
+    },
+    "engines": {
+        "node": ">=18"
+    },
     "publishConfig": {
         "access": "public"
     },


### PR DESCRIPTION
package.json declared "license": "MIT" but the repo shipped no actual LICENSE file — npm always includes LICENSE/README/package.json in the published tarball regardless of the files field, so this was a real gap, not cosmetic. Also missing: repository, homepage, bugs, author, and engines fields — without repository, npmjs.com won't show a link back to the GitHub repo.

- Added the standard MIT LICENSE file
- Added repository, homepage, bugs, author (Lewie Jackson), and engines (node >=18, matching what the README already claims) to package.json
- npm pack --dry-run confirms LICENSE now ships — 129 files, up from 128
- npm run build, npm test (188/188), and format:check all clean

Found during a full pre-publish audit — not tied to a tracked GitHub issue.