### PR TITLE
Add examples type-checking to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,6 @@ jobs:
 
             - run: npm ci
             - run: npm run build
+            - run: npm run typecheck:examples
             - run: npm test
             - run: npm run format:check

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "format:check": "prettier . --check",
         "test": "jest",
         "test:watch": "jest --watch",
-        "test:coverage": "jest --coverage"
+        "test:coverage": "jest --coverage",
+        "typecheck:examples": "tsc -p tsconfig.examples.json"
     },
     "keywords": [
         "github",

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "paths": {
+            "@lujax/github-sdk": ["./src/index.ts"]
+        }
+    },
+    "include": ["examples/**/*"],
+    "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
examples/ was never type-checked anywhere — not by npm run build (only src/ and tests/ are in tsconfig.json's include), and not by CI. This is exactly how the user.login typo in basic-usage.ts (fixed earlier this session) slipped through the #56 docs/examples audit undetected.

- Added tsconfig.examples.json, which type-checks examples/**/* against the real SDK source via a paths mapping (@lujax/github-sdk → ./src/index.ts), since the package isn't installed from npm during local dev and the bare import needs somewhere to resolve to
- New typecheck:examples script, wired into ci.yml between build and test
- Verified it actually catches the bug it's meant to: temporarily reintroduced user.login, confirmed tsc fails with Property 'login' does not exist on type 'User', then reverted
- npm run build, npm run typecheck:examples, npm test (188/188), and format:check all clean

Not tied to a tracked GitHub issue — found and closed during the pre-publish audit.