### PR TITLE
Add npm version and CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # @lujax/github-sdk
 
+[![npm version](https://img.shields.io/npm/v/%40lujax%2Fgithub-sdk.svg)](https://www.npmjs.com/package/@lujax/github-sdk)
+[![CI](https://github.com/lujax-dev/github-sdk/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/lujax-dev/github-sdk/actions/workflows/ci.yml)
+
 A TypeScript-first, ergonomic wrapper around the [GitHub REST API](https://docs.github.com/en/rest). Calls `api.github.com` directly using native `fetch` — no Octokit, no third-party HTTP library.
 
 - **Clean TypeScript domain types** — camelCase interfaces instead of raw snake_case API responses


### PR DESCRIPTION
Adds two badges under the README title:
- npm version (```img.shields.io/npm/v/@lujax/github-sdk```) — links to the npm package page
- CI status (```github.com/lujax-dev/github-sdk/actions/workflows/ci.yml/badge.svg```) — live from the existing ```ci.yml``` workflow, no new secrets/services needed

Originally scoped as npm version + a test-coverage badge, but a dynamic coverage badge needs a third-party service (Codecov) requiring an account + repo secret — decided to keep it to two badges backed entirely by things we already have (npm registry + existing CI) rather than add an external dependency for this. Coverage can be revisited later if there's real demand.

No code changes — README.md only.

Closes #77