### PR TITLE
docs: add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+---
+
+## Steps to reproduce
+
+<!-- Minimal code snippet or steps -->
+
+## Expected behaviour
+
+## Actual behaviour
+
+<!-- Include the error message / stack trace if there is one -->
+
+## Environment
+
+- SDK version:
+- Node version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+labels: enhancement
+---
+
+## Problem
+
+<!-- What are you trying to do that the SDK doesn't support (well)? -->
+
+## Proposed solution
+
+## Alternatives considered
+
+<!-- Workarounds you tried, or other API shapes that could work -->


### PR DESCRIPTION
## Description

Adds the two issue templates requested in #82 under `.github/ISSUE_TEMPLATE/`:

- **bug_report.md** — steps to reproduce, expected vs actual behaviour, SDK version, Node version; auto-labels `bug`
- **feature_request.md** — problem being solved, proposed solution, alternatives considered; auto-labels `enhancement`

Both are a few fields each, per the issue's "not a form nobody wants to fill in" guidance.

## Related issue

Closes #82

## Notes

Front-matter follows GitHub's issue-template schema (`name` / `about` / `labels`); the templates will show up in the "New issue" chooser once merged to the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
