### PR TITLE
docs: add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+---
+
+## Steps to reproduce
+
+<!-- Minimal code snippet or steps -->
+
+## Expected behaviour
+
+## Actual behaviour
+
+<!-- Include the error message / stack trace if there is one -->
+
+## Environment
+
+- SDK version:
+- Node version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+labels: enhancement
+---
+
+## Problem
+
+<!-- What are you trying to do that the SDK doesn't support (well)? -->
+
+## Proposed solution
+
+## Alternatives considered
+
+<!-- Workarounds you tried, or other API shapes that could work -->


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md` so incoming issues arrive with repro steps / environment (bug) or problem / proposed API (feature), and get labeled `bug` / `enhancement` automatically.

Companion to #92; both only add files under `.github/`, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)